### PR TITLE
Fixed "Ok" in dialogs to "OK"

### DIFF
--- a/ui/create-repo-dialog.ui
+++ b/ui/create-repo-dialog.ui
@@ -155,7 +155,7 @@
      <item>
       <widget class="QPushButton" name="mOkBtn">
        <property name="text">
-        <string>Ok</string>
+        <string>OK</string>
        </property>
       </widget>
      </item>

--- a/ui/download-repo-dialog.ui
+++ b/ui/download-repo-dialog.ui
@@ -240,7 +240,7 @@ min-width: 300px;
      <item>
       <widget class="QPushButton" name="mOkBtn">
        <property name="text">
-        <string>Ok</string>
+        <string>OK</string>
        </property>
       </widget>
      </item>

--- a/ui/settings-dialog.ui
+++ b/ui/settings-dialog.ui
@@ -170,7 +170,7 @@
      <item>
       <widget class="QPushButton" name="mOkBtn">
        <property name="text">
-        <string>Ok</string>
+        <string>OK</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
The initials "OK" are more grammatically and historically correct than the word "Ok" which, in English, would be literally pronounced "ock".
