### PR TITLE
[ci] add coverity support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: cpp
+env:
+  global:
+   - secure: "VGKP/MgL+kk+DToAlMyZCN6id17oydM69yR8RC0jI9RKM73Jgsyb5iRUbP3UOpqhl/dZQB5dt14I8HMneyy7lskd+l5RNMrh5yPxM4/D9PrRhwte9xZhrDXoAi79GyRDidNhyt6g6rM3uViPe/K41c9qJy3ZY4P/t/uMq5hFKfs="
 matrix:
   include:
     - os: linux
@@ -13,13 +16,25 @@ matrix:
     - os: linux
       compiler: clang
       env: USE_QT5=1
+    - os: osx
+      compiler: clang
+      env: USE_QT5=1
   exclude:
     - os: osx
       compiler: gcc
 before_install:
  - ./scripts/install-deps-${TRAVIS_OS_NAME}.sh
 script:
- - ./scripts/ci-build.sh
+ - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then ./scripts/ci-build.sh ; fi
+addons:
+  coverity_scan:
+    project:
+      name: "haiwen/seafile-client"
+      description: "Build submitted via Travis CI"
+    notification_email: rwindz0@gmail.com
+    build_command_prepend: "git clean -xfd"
+    build_command:   "./scripts/ci-build.sh"
+    branch_pattern: coverity_scan
 notifications:
   email:
     recipients:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## seafile-client [![Build Status](https://secure.travis-ci.org/haiwen/seafile-client.svg?branch=master)](http://travis-ci.org/haiwen/seafile-client)
+## seafile-client [![Build Status](https://secure.travis-ci.org/haiwen/seafile-client.svg?branch=master)](http://travis-ci.org/haiwen/seafile-client) [![Coverity Scan Build Status](https://scan.coverity.com/projects/3121/badge.svg)](https://scan.coverity.com/projects/3121)
 
 
 New version of Seafile desktop client.

--- a/scripts/install-deps-osx.sh
+++ b/scripts/install-deps-osx.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -x
 set -e
-## TODO: use the correct version of seafile for each branch
 
 brew up
-brew install qt4
+brew install qt5
+brew link qt5
 
 brew tap Chilledheart/seafile
 brew install --HEAD libsearpc ccnet seafile


### PR DESCRIPTION
- coverity scan is static analysis tool which is run by https://scan.coverity.com/
- coverity scan build is limited to 3 times one day https://scan.coverity.com/faq#frequency
- coverity scan is only to be run at branch coverity_scan (branch_pattern) due the reason described above
- reports available [here](https://scan.coverity.com/projects/3121)
