### PR TITLE
Move seafile-applet manual from seafile package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,11 @@ install(FILES
   DESTINATION share/pixmaps
 )
 
+install(FILES
+  ${CMAKE_SOURCE_DIR}/doc/seafile-applet.1
+  DESTINATION share/man1
+)
+
 endif()
 
 ####################

--- a/doc/seafile-applet.1
+++ b/doc/seafile-applet.1
@@ -1,0 +1,24 @@
+.\" Manpage for seafile-client
+.\" Contact freeplant@gmail.com to correct errors or typos.
+.TH seafile 1 "31 Jan 2013" "Linux" "seafile-client man page"
+.SH NAME
+seafile-applet \- start the seafile client
+.SH SYNOPSIS
+seafile-applet [OPTIONS]
+.SH DESCRIPTION
+.BR seafile-applet
+is the client program of seafile. It will start
+.BR ccnet(1)
+, 
+.BR seaf-daemon(1)
+, 
+.BR seafile-web(1)
+for you
+.SH SEE ALSO
+ccnet(1), seaf-daemon(1), seafile-web(1), seaf-cli(1)
+.SH AUTHOR
+Lingtao Pan (freeplant@gmail.com)
+.SH WEBSTIE
+http://www.seafile.com
+.LP
+https://github.com/haiwen/seafile/


### PR DESCRIPTION
Hi!
This patch moves seafile-applet manual from seafile to seafile-client.
I'll send another patch for seafile to prevent conflicts.
