### PR TITLE
fixed resync an encrypted library

### DIFF
--- a/src/ui/download-repo-dialog.cpp
+++ b/src/ui/download-repo-dialog.cpp
@@ -257,3 +257,9 @@ void DownloadRepoDialog::onDownloadRepoRequestFailed(const ApiError& error)
 
     setAllInputsEnabled(true);
 }
+
+void DownloadRepoDialog::setMergeWithExisting(const QString& localPath) {
+    mode_ = MERGE_WITH_EXISTING_FOLDER;
+    updateSyncMode();
+    mDirectory->setText(localPath);
+}

--- a/src/ui/download-repo-dialog.h
+++ b/src/ui/download-repo-dialog.h
@@ -18,6 +18,8 @@ public:
                        const ServerRepo& repo,
                        QWidget *parent=0);
 
+    void setMergeWithExisting(const QString& localPath);
+
 private slots:
     void onOkBtnClicked();
     void chooseDirAction();

--- a/src/ui/repo-tree-view.cpp
+++ b/src/ui/repo-tree-view.cpp
@@ -553,6 +553,7 @@ void RepoTreeView::resyncRepo()
     if (server_repo.encrypted) {
         DownloadRepoDialog dialog(seafApplet->accountManager()->currentAccount(),
                                   RepoService::instance()->getRepo(server_repo.id), this);
+        dialog.setMergeWithExisting(local_repo.worktree);
         dialog.exec();
         return;
     } else {


### PR DESCRIPTION
We need put the download dialog into "merge with existing folder" mode when resyncing an encrypted library.
