### PR TITLE
fix the rare case of segment fault while uploading files

### DIFF
--- a/src/filebrowser/progress-dialog.cpp
+++ b/src/filebrowser/progress-dialog.cpp
@@ -74,6 +74,12 @@ void FileBrowserProgressDialog::onProgressUpdate(qint64 processed_bytes, qint64 
 {
     if (maximum() != total_bytes)
         setMaximum(total_bytes);
+
+    // if the value is less than the maxmium, this dialog will close itself
+    // add this guard for safety
+    if (processed_bytes >= total_bytes)
+        setMaximum(processed_bytes + 1);
+
     setValue(processed_bytes);
 
     more_details_label_->setText(tr("%1 of %2")

--- a/src/filebrowser/tasks.cpp
+++ b/src/filebrowser/tasks.cpp
@@ -609,7 +609,9 @@ void PostFilesTask::prepare()
     Q_FOREACH(const QString &name, names_)
     {
         QString local_path = ::pathJoin(local_path_, name);
-        qint64 file_size = QFileInfo(local_path).size();
+        // approximate the bytes used by http protocol (e.g. the bytes of
+        // header)
+        qint64 file_size = QFileInfo(local_path).size() + 1024;
         file_sizes.push_back(file_size);
         total_bytes_ += file_size;
     }
@@ -626,7 +628,7 @@ void PostFilesTask::sendRequest()
     startNext();
 }
 
-void PostFilesTask::onPostTaskProgressUpdate(qint64 bytes, qint64 /* sum_bytes*/)
+void PostFilesTask::onPostTaskProgressUpdate(qint64 bytes, qint64 /* sum_bytes */)
 {
     emit progressUpdate(current_bytes_ + bytes, total_bytes_);
 }
@@ -641,7 +643,7 @@ void PostFilesTask::onPostTaskFinished(bool success)
     }
     error_ = task_->error();
     error_string_ = task_->errorString();
-    http_error_code_ =  task_->httpErrorCode();
+    http_error_code_ = task_->httpErrorCode();
     emit finished(false);
 }
 

--- a/src/filebrowser/tasks.h
+++ b/src/filebrowser/tasks.h
@@ -366,7 +366,8 @@ private:
     struct doDeleteLater
     {
         static inline void cleanup(T *pointer) {
-            pointer->deleteLater();
+            if (pointer != NULL)
+                pointer->deleteLater();
         }
     };
 


### PR DESCRIPTION
caused by the dialog automatically closing before the task is finished due to
the fact that the value is large than the maximum.

this patch adds guard to prevent it. and it also applies some human fixes for
the incorrect total_bytes during uploading (aka. not counting the network
 or http protocol cost).