### PR TITLE
fix the rare case of segment fault while uploading files

### DIFF
--- a/src/filebrowser/progress-dialog.cpp
+++ b/src/filebrowser/progress-dialog.cpp
@@ -44,6 +44,10 @@ FileBrowserProgressDialog::FileBrowserProgressDialog(FileNetworkTask *task, QWid
     initTaskInfo();
 }
 
+FileBrowserProgressDialog::~FileBrowserProgressDialog()
+{
+}
+
 void FileBrowserProgressDialog::initTaskInfo()
 {
     QString title, label;
@@ -72,8 +76,14 @@ void FileBrowserProgressDialog::initTaskInfo()
 
 void FileBrowserProgressDialog::onProgressUpdate(qint64 processed_bytes, qint64 total_bytes)
 {
+    // if the value is less than the maxmium, this dialog will close itself
+    // add this guard for safety
+    if (processed_bytes >= total_bytes)
+        total_bytes = processed_bytes + 1;
+
     if (maximum() != total_bytes)
         setMaximum(total_bytes);
+
     setValue(processed_bytes);
 
     more_details_label_->setText(tr("%1 of %2")

--- a/src/filebrowser/progress-dialog.h
+++ b/src/filebrowser/progress-dialog.h
@@ -15,6 +15,7 @@ class FileBrowserProgressDialog : public QProgressDialog {
     Q_OBJECT
 public:
     FileBrowserProgressDialog(FileNetworkTask *task, QWidget *parent=0);
+    ~FileBrowserProgressDialog();
 
 public slots:
     void cancel();

--- a/src/filebrowser/tasks.h
+++ b/src/filebrowser/tasks.h
@@ -354,6 +354,7 @@ protected:
 
 private slots:
     void cancel();
+    void onProgressUpdate();
     void onPostTaskProgressUpdate(qint64, qint64);
     void onPostTaskFinished(bool success);
 
@@ -366,7 +367,8 @@ private:
     struct doDeleteLater
     {
         static inline void cleanup(T *pointer) {
-            pointer->deleteLater();
+            if (pointer != NULL)
+                pointer->deleteLater();
         }
     };
 
@@ -377,8 +379,14 @@ private:
 
     QScopedPointer<PostFileTask, doDeleteLater<PostFileTask> > task_;
     int current_num_;
+    // transferred bytes in the current tasks
     qint64 current_bytes_;
+    // the total bytes of completely transferred tasks
+    qint64 transferred_bytes_;
+    // the total bytes of all tasks
     qint64 total_bytes_;
+    // deal with the qt4 eventloop's bug
+    QTimer *progress_update_timer_;
     const bool use_relative_;
 };
 


### PR DESCRIPTION
caused by the dialog automatically closing before the task is finished due to
the fact that the value is large than the maximum.

this patch adds guard to prevent it. and it also applies some human fixes for
the incorrect total_bytes during uploading (aka. not counting the network
 or http protocol cost).