### PR TITLE
enlarge the size of settings dialog

### DIFF
--- a/qt.css
+++ b/qt.css
@@ -260,11 +260,11 @@ QLabel#loadingFailedText {
 }
 
 SettingsDialog {
-    min-width: 450px;
-    max-width: 450px;
+    min-width: 560px;
+    max-width: 560px;
 
-    min-height: 350px;
-    max-height: 350px;
+    min-height: 390px;
+    max-height: 390px;
 }
 
 SettingsDialog QTabWidget::pane QLabel#desc,


### PR DESCRIPTION
In some languages, the size of settisn dialog is too small to show
the settings.

This should fix #421.

(the dialog compared with is ubuntu's bluetooth setting dialog)

![screen shot 2015-01-19 at 13 28 28](https://cloud.githubusercontent.com/assets/2123461/5796250/5589d806-9fdf-11e4-996c-e184dd107be3.png)
![screen shot 2015-01-19 at 13 28 34](https://cloud.githubusercontent.com/assets/2123461/5796251/559b280e-9fdf-11e4-86c3-cb09e7ef9149.png)
