### PR TITLE
qt5: build under c++11 mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,10 @@ IF(USE_QT5)
       SET(USE_QT_LIBRARIES ${USE_QT_LIBRARIES} "DBus")
     ENDIF()
     FIND_PACKAGE(Qt5 REQUIRED ${USE_QT_LIBRARIES})
+    # from QT 5.4.0 Changelog
+    # The Qt binary packages are now configured with C++11 enabled.
+    # this requires your gcc compiler newer than 4.8.1 or clang newer than 3.3
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
     IF (BUILD_SHIBBOLETH_SUPPORT)
       SET(QtWebKit "QtWebKit")

--- a/scripts/install-deps-linux.sh
+++ b/scripts/install-deps-linux.sh
@@ -4,9 +4,13 @@ set -e
 
 sudo add-apt-repository -y ppa:smspillaz/cmake-2.8.12
 sudo add-apt-repository -y ppa:beineri/opt-qt54
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update -qq
+sudo apt-get install -y gcc-4.8 g++-4.8
 sudo apt-get install -y valac uuid-dev libevent-dev re2c libjansson-dev cmake cmake-data libqt4-dev
 sudo apt-get install -y qt54base qt54translations qt54tools qt54webkit
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 git clone --depth=1 --branch=master git://github.com/haiwen/libsearpc.git deps/libsearpc
 git clone --depth=1 --branch=master git://github.com/haiwen/ccnet.git deps/ccnet

--- a/src/filebrowser/file-browser-dialog.cpp
+++ b/src/filebrowser/file-browser-dialog.cpp
@@ -650,7 +650,7 @@ void FileBrowserDialog::onUploadFinished(bool success)
           SeafDirent::FILE,
           "",
           name,
-          file.size(),
+          static_cast<quint64>(file.size()),
           QDateTime::currentDateTime().toTime_t()
         };
         if (task->useUpload())


### PR DESCRIPTION
if we are building against qt5, build under c++11 mode for binary consistence.
this requires your compiler newer than gcc 4.8.1 or clang 3.3.
and, currently, it is guarenteed under osx.

from [qt 5.4.0's changelog](https://qt.gitorious.org/qt/qtbase/source/64c6bfd1f45f532ea32de49431b66e03e7593f01:dist/changes-5.4.0#L443-449)
"The Qt binary packages (for OS X) are now configured with C++11 enabled."