### PR TITLE
osx: show correctly by clicking the dock icon while mainwidget is hidden

### DIFF
--- a/src/ui/main-window.cpp
+++ b/src/ui/main-window.cpp
@@ -93,6 +93,11 @@ MainWindow::MainWindow()
 
     createActions();
     setAttribute(Qt::WA_TranslucentBackground, true);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+    connect(qApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)),
+            this, SLOT(checkShowWindow()));
+#endif
 }
 
 void MainWindow::hide()
@@ -150,6 +155,16 @@ void MainWindow::showEvent(QShowEvent *event)
 #endif
     QWidget::showEvent(event);
 
+}
+
+// handle osx's applicationShouldHandleReopen
+// QTBUG-10899 OS X: Add support for ApplicationState capability
+void MainWindow::checkShowWindow()
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+    if (qApp->applicationState() & Qt::ApplicationActive)
+        showWindow();
+#endif
 }
 
 void MainWindow::createActions()

--- a/src/ui/main-window.h
+++ b/src/ui/main-window.h
@@ -32,6 +32,7 @@ private slots:
     void refreshQss();
     void closeEvent(QCloseEvent *event);
     void showEvent(QShowEvent *event);
+    void checkShowWindow(); //dummy slot if qt version is lower than 5.2.0
 
 private:
     Q_DISABLE_COPY(MainWindow)


### PR DESCRIPTION
- see more https://bugreports.qt.io/browse/QTBUG-10899
- this bug (or so-called new feature) is introduced by Qt 5.4
