### PR TITLE
drop workaround with QTBUG-40449 if using qt 5.4.1 or later

### DIFF
--- a/src/filebrowser/file-table.cpp
+++ b/src/filebrowser/file-table.cpp
@@ -560,9 +560,8 @@ void FileTableView::dropEvent(QDropEvent *event)
     Q_FOREACH(const QUrl& url, urls)
     {
         QString path = url.toLocalFile();
-#ifdef Q_OS_MAC
-        if (path.startsWith("/.file/id="))
-            path = utils::mac::get_path_from_fileId_url("file://" + path);
+#if defined(Q_OS_MAC) && (QT_VERSION <= QT_VERSION_CHECK(5, 4, 0))
+        path = utils::mac::fix_file_id_url(path);
 #endif
 
         if(path.isEmpty())

--- a/src/ui/cloud-view.cpp
+++ b/src/ui/cloud-view.cpp
@@ -275,9 +275,8 @@ bool CloudView::eventFilter(QObject *obj, QEvent *event)
                 const QUrl url = ev->mimeData()->urls().at(0);
                 if (url.scheme() == "file") {
                     QString path = url.toLocalFile();
-#ifdef Q_OS_MAC
-                    if (path.startsWith("/.file/id="))
-                        path = utils::mac::get_path_from_fileId_url("file://" + path);
+#if defined(Q_OS_MAC) && (QT_VERSION <= QT_VERSION_CHECK(5, 4, 0))
+                    path = utils::mac::fix_file_id_url(path);
 #endif
                     if (QFileInfo(path).isDir()) {
                         ev->acceptProposedAction();
@@ -289,9 +288,8 @@ bool CloudView::eventFilter(QObject *obj, QEvent *event)
             QDropEvent *ev = (QDropEvent *)event;
             const QUrl url = ev->mimeData()->urls().at(0);
             QString path = url.toLocalFile();
-#ifdef Q_OS_MAC
-            if (path.startsWith("/.file/id="))
-                path = utils::mac::get_path_from_fileId_url("file://" + path);
+#if defined(Q_OS_MAC) && (QT_VERSION <= QT_VERSION_CHECK(5, 4, 0))
+            path = utils::mac::fix_file_id_url(path);
 #endif
             showCreateRepoDialog(path);
             return true;

--- a/src/ui/repo-tree-view.cpp
+++ b/src/ui/repo-tree-view.cpp
@@ -721,9 +721,8 @@ void RepoTreeView::dropEvent(QDropEvent *event)
     const QUrl url = event->mimeData()->urls().at(0);
 
     QString local_path = url.toLocalFile();
-#ifdef Q_OS_MAC
-    if (local_path.startsWith("/.file/id="))
-        local_path = utils::mac::get_path_from_fileId_url("file://" + local_path);
+#if defined(Q_OS_MAC) && (QT_VERSION <= QT_VERSION_CHECK(5, 4, 0))
+        local_path = utils::mac::fix_file_id_url(local_path);
 #endif
     const QString file_name = QFileInfo(local_path).fileName();
 
@@ -777,9 +776,8 @@ void RepoTreeView::dragEnterEvent(QDragEnterEvent *event)
         if (url.scheme() == "file") {
 
             QString file_name = url.toLocalFile();
-#ifdef Q_OS_MAC
-            if (file_name.startsWith("/.file/id="))
-                file_name = utils::mac::get_path_from_fileId_url("file://" + file_name);
+#if defined(Q_OS_MAC) && (QT_VERSION <= QT_VERSION_CHECK(5, 4, 0))
+            file_name = utils::mac::fix_file_id_url(file_name);
 #endif
 
             if (QFileInfo(file_name).isFile()) {

--- a/src/utils/utils-mac.h
+++ b/src/utils/utils-mac.h
@@ -10,7 +10,7 @@ void setDockIconStyle(bool);
 bool get_auto_start();
 void set_auto_start(bool enabled);
 
-QString get_path_from_fileId_url(const QString &url);
+QString fix_file_id_url(const QString &path);
 
 } // namespace mac
 } // namespace utils

--- a/src/utils/utils-mac.mm
+++ b/src/utils/utils-mac.mm
@@ -27,12 +27,12 @@ void setDockIconStyle(bool hidden) {
     }
 }
 
-// Yosemite uses a new url format called fileId url, use this helper to transform
-// it to the old style.
-// https://bugreports.qt-project.org/browse/QTBUG-40449
-// NSString *fileIdURL = @"file:///.file/id=6571367.1000358";
-// NSString *goodURL = [[NSURL URLWithString:fileIdURL] filePathURL];
-QString get_path_from_fileId_url(const QString &url) {
+// https://bugreports.qt-project.org/browse/QTBUG-40449 is fixed in QT 5.4.1
+// TODO remove this and related code once qt 5.4.1 is widely used
+QString fix_file_id_url(const QString &path) {
+    if (!path.startsWith("/.file/id="))
+        return path;
+    const QString url = "file://" + path;
     NSString *fileIdURL = [NSString stringWithCString:url.toUtf8().data()
                                     encoding:NSUTF8StringEncoding];
     NSURL *goodURL = [[NSURL URLWithString:fileIdURL] filePathURL];


### PR DESCRIPTION
- [QTBUG 40449](https://bugreports.qt.io/browse/QTBUG-40449) is fixed in qt5.4.1
- TODO remove this workaround and related code totally once qt 5.4.1 is widely used