### PR TITLE
fix a bug that settings dialog still write discarded changes on settings

### DIFF
--- a/src/ui/settings-dialog.cpp
+++ b/src/ui/settings-dialog.cpp
@@ -79,14 +79,32 @@ void SettingsDialog::closeEvent(QCloseEvent *event)
     this->hide();
 }
 
+void SettingsDialog::reject()
+{
+    // reset settings
+    // this fix a bug writing discarded settings when exiting program
+    readSettings();
+
+    QDialog::reject();
+}
+
 void SettingsDialog::showEvent(QShowEvent *event)
+{
+    SettingsManager *mgr = seafApplet->settingsManager();
+
+    mgr->loadSettings();
+
+    readSettings();
+
+    QDialog::showEvent(event);
+}
+
+void SettingsDialog::readSettings()
 {
     Qt::CheckState state;
     int ratio;
 
     SettingsManager *mgr = seafApplet->settingsManager();
-
-    mgr->loadSettings();
 
     state = mgr->hideMainWindowWhenStarted() ? Qt::Checked : Qt::Unchecked;
     mHideMainWinCheckBox->setCheckState(state);
@@ -134,8 +152,6 @@ void SettingsDialog::showEvent(QShowEvent *event)
     }
 
     mLanguageComboBox->setCurrentIndex(I18NHelper::getInstance()->preferredLanguage());
-
-    QDialog::showEvent(event);
 }
 
 

--- a/src/ui/settings-dialog.h
+++ b/src/ui/settings-dialog.h
@@ -6,13 +6,14 @@
 
 
 class SettingsDialog : public QDialog,
-                    public Ui::SettingsDialog
+                       public Ui::SettingsDialog
 {
     Q_OBJECT
 public:
     SettingsDialog(QWidget *parent=0);
 
 private slots:
+    void reject();
 
     void autoStartChanged(int state);
     void hideDockIconChanged(int state);
@@ -24,5 +25,6 @@ private slots:
     void updateSettings();
 
 private:
+    void readSettings();
     Q_DISABLE_COPY(SettingsDialog);
 };


### PR DESCRIPTION
reproduce procedures:
- change language or proxy settings
- click cancel to discard current changes
- exit program directly
- get an alert that language or proxy settings has been changed and app requires a restart

This bug exists in previous versions as well.