### PR TITLE
Fix seafile-applet on ARM

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@ void setupSettingDomain()
 
 void handleCommandLineOption(int argc, char *argv[])
 {
-    char c;
+    int c;
     static const char *short_options = "KXc:d:f:";
     static const struct option long_options[] = {
         { "config-dir", required_argument, NULL, 'c' },


### PR DESCRIPTION
getopt_long() returns an int, which is signed.  The existing code casts
this int to a char, which on ARM is unsigned.

Due to how casting works, the resulting value is invalid, and will always
produce an error on ARM.  This prevents seafile-applet from running at all,
as it silently quits before any command line arguments are parsed.

The solution is to change 'char c' to 'int c', which allows for negative
values, and lets getopt_long() work as intended.

Signed-off-by: Sean Cross <xobs@kosagi.com>