### PR TITLE
fix windows build under mingw32

### DIFF
--- a/src/utils/process-win.cpp
+++ b/src/utils/process-win.cpp
@@ -1,3 +1,6 @@
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501
+#endif
 #include <windows.h>
 #include <psapi.h>
 


### PR DESCRIPTION
`_WIN32_WINNT` is not set under mingw32. set its value to match Windows XP.