### PR TITLE
Fix a bug that when we turn on "hide the docker icon" the main window sinks

### DIFF
--- a/src/settings-mgr.cpp
+++ b/src/settings-mgr.cpp
@@ -2,12 +2,14 @@
 #include <QHostInfo>
 #include <QNetworkProxy>
 #include "utils/utils.h"
+#include "utils/utils-mac.h"
 #include "seafile-applet.h"
 #include "ui/tray-icon.h"
 #include "settings-mgr.h"
 #include "rpc/rpc-client.h"
 #include "utils/utils.h"
 #include "network-mgr.h"
+#include "ui/main-window.h"
 
 #if defined(Q_OS_WIN32)
 #include "utils/registry.h"
@@ -236,6 +238,12 @@ void SettingsManager::setHideDockIcon(bool hide)
     settings.endGroup();
 
     set_seafile_dock_icon_style(hide);
+#ifdef Q_OS_MAC
+    // for UIElement application, the main window might sink
+    // under many applications
+    // this will force it to stand before all
+    utils::mac::orderFrontRegardless(seafApplet->mainWindow()->winId());
+#endif
 }
 
 // void SettingsManager::setDefaultLibraryAlreadySetup()

--- a/src/ui/main-window.cpp
+++ b/src/ui/main-window.cpp
@@ -23,6 +23,7 @@
 #include "tray-icon.h"
 #include "login-dialog.h"
 #include "utils/utils.h"
+#include "utils/utils-mac.h"
 
 #include "main-window.h"
 
@@ -194,6 +195,10 @@ void MainWindow::showWindow()
     show();
     raise();
     activateWindow();
+    // a hack with UIElement application
+#ifdef Q_OS_MAC
+    utils::mac::orderFrontRegardless(seafApplet->mainWindow()->winId());
+#endif
 }
 
 void MainWindow::refreshQss()

--- a/src/utils/utils-mac.h
+++ b/src/utils/utils-mac.h
@@ -1,4 +1,5 @@
 #ifndef SEAFILE_CLIENT_UTILS_MAC_H_
+#define SEAFILE_CLIENT_UTILS_MAC_H_
 #include <QtGlobal>
 #ifdef Q_OS_MAC
 #include <QString>
@@ -8,7 +9,8 @@ typedef void DarkModeChangedCallback(bool value);
 namespace utils {
 namespace mac {
 
-void setDockIconStyle(bool);
+void setDockIconStyle(bool hidden);
+void orderFrontRegardless(unsigned long long win_id, bool force = false);
 bool get_auto_start();
 void set_auto_start(bool enabled);
 


### PR DESCRIPTION

- fix the non-functionality of this option on OS X 10.7

- details are mentioned by https://forum.seafile-server.org/t/solved-hide-os-x-sync-client-from-dock/964