### PR TITLE
mac: fix copy text to pasteboard issue

### DIFF
--- a/src/filebrowser/sharedlink-dialog.cpp
+++ b/src/filebrowser/sharedlink-dialog.cpp
@@ -6,6 +6,7 @@
 #else
 #include <QtGui>
 #endif
+#include "utils/utils-mac.h"
 
 SharedLinkDialog::SharedLinkDialog(const QString &text, QWidget *parent)
   : text_(text)
@@ -53,6 +54,12 @@ SharedLinkDialog::SharedLinkDialog(const QString &text, QWidget *parent)
 
 void SharedLinkDialog::onCopyText()
 {
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setText(text_);
+
+// for mac, qt copys many minedatas beside public.utf8-plain-text
+// e.g. public.vcard, which we don't want to use
+#ifndef Q_OS_MAC
+    QApplication::clipboard()->setText(text_);
+#else
+    utils::mac::copyTextToPasteboard(text_);
+#endif
 }

--- a/src/utils/utils-mac.h
+++ b/src/utils/utils-mac.h
@@ -11,6 +11,7 @@ namespace mac {
 void setDockIconStyle(bool);
 bool get_auto_start();
 void set_auto_start(bool enabled);
+void copyTextToPasteboard(const QString &text);
 
 bool is_darkmode();
 void set_darkmode_watcher(DarkModeChangedCallback *cb);

--- a/src/utils/utils-mac.mm
+++ b/src/utils/utils-mac.mm
@@ -225,5 +225,13 @@ void get_current_osx_version(unsigned *major, unsigned *minor, unsigned *patch) 
 #endif
 }
 
+void copyTextToPasteboard(const QString &text) {
+    NSString *text_data = [NSString stringWithUTF8String:text.toUtf8().data()];
+    NSPasteboard *paste_board = [NSPasteboard generalPasteboard];
+    [paste_board clearContents];
+    [paste_board declareTypes:[NSArray arrayWithObjects:NSStringPboardType, nil] owner:nil];
+    [paste_board writeObjects:@[text_data]];
+}
+
 } // namespace mac
 } // namespace utils


### PR DESCRIPTION
for mac, qt copys many minedatas beside public.utf8-plain-text
e.g. public.vcard, which we don't want to use