### PR TITLE
[OSX] add sparkle support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/Sparkle"]
+	path = third_party/Sparkle
+	url = https://github.com/sparkle-project/Sparkle

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ OPTION(BUILD_DOCS "Build Documents" OFF)
 
 OPTION(BUILD_SHIBBOLETH_SUPPORT "Build Shibboleth support" OFF)
 
+OPTION(BUILD_SPARKLE_SUPPORT "Build Sparkle Support (OS X Only)" OFF)
+
 option(BUILD_ENABLE_WARNINGS "Enable compiler warnings." ON)
 
 MESSAGE("Build type: ${CMAKE_BUILD_TYPE}")
@@ -158,6 +160,33 @@ ELSE()
     FIND_PACKAGE(Qt4 REQUIRED QtCore QtGui QtNetwork ${QtDBus} ${QtWebKit})
     INCLUDE(${QT_USE_FILE})
 ENDIF()
+
+###############################################################################
+## Sparkle Support (OSX Only)
+###############################################################################
+
+IF (BUILD_SPARKLE_SUPPORT AND NOT CMAKE_GENERATOR STREQUAL Xcode)
+    MESSAGE(FATAL_ERROR "Sparkle support is only supported on xcode")
+ENDIF()
+
+IF (BUILD_SPARKLE_SUPPORT)
+    ADD_DEFINITIONS(-DHAVE_SPARKLE_SUPPORT)
+    SET(platform_specific_sources ${platform_specific_sources} src/sparkle-support.mm)
+    SET_SOURCE_FILES_PROPERTIES(src/sparkle-support.mm
+      PROPERTIES COMPILE_FLAGS -fobjc-arc)
+
+    SET(SPARKLE_FRAMEWORK
+      ${CMAKE_CURRENT_SOURCE_DIR}/third_party/Sparkle/build/Release/Sparkle.framework)
+    INCLUDE_DIRECTORIES(${SPARKLE_FRAMEWORK}/Headers)
+
+    ADD_CUSTOM_TARGET(build-sparkle
+      COMMAND xcodebuild -arch x86_64 -target Sparkle -configuration Release MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/third_party/Sparkle)
+ENDIF()
+
+###############################################################################
+## Qt Sources
+###############################################################################
 
 # MOC FILES
 SET(moc_headers
@@ -704,6 +733,13 @@ TARGET_LINK_LIBRARIES(seafile-applet
   ${EXTRA_LIBS}
 )
 
+IF(BUILD_SPARKLE_SUPPORT)
+  ADD_DEPENDENCIES(seafile-applet build-sparkle)
+  TARGET_LINK_LIBRARIES(seafile-applet
+    ${SPARKLE_FRAMEWORK}
+    )
+ENDIF()
+
 IF(USE_QT5)
   QT5_USE_MODULES(seafile-applet Core Gui Widgets Network)
   IF (BUILD_SHIBBOLETH_SUPPORT)
@@ -738,6 +774,14 @@ IF(CMAKE_GENERATOR STREQUAL Xcode)
       COMMAND ${CMAKE_COMMAND} -E copy ${ccnet} ${RESOURCES_DIR}/.
       COMMAND ${CMAKE_COMMAND} -E copy ${seaf-daemon} ${RESOURCES_DIR}/.
   )
+  SET(FRAMEWORKS_DIR ${CMAKE_CURRENT_BINARY_DIR}/\${CONFIGURATION}/seafile-applet.app/Contents/Frameworks)
+  IF(BUILD_SPARKLE_SUPPORT)
+      ADD_CUSTOM_COMMAND(TARGET seafile-applet
+          POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E make_directory ${FRAMEWORKS_DIR}
+          COMMAND cp -r ${SPARKLE_FRAMEWORK} ${FRAMEWORKS_DIR}/.
+  )
+  ENDIF(BUILD_SPARKLE_SUPPORT)
   SET(CMAKE_XCODE_ATTRIBUTE_GCC_GENERATE_DEBUGGING_SYMBOLS "YES")
   SET(CMAKE_XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT "dwarf-with-dsym")
   SET(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_PASCAL_STRINGS "NO")

--- a/Info.plist
+++ b/Info.plist
@@ -14,6 +14,8 @@
 	<string>APPL</string>
 	<key>CFBundleName</key>
 	<string>Seafile</string>
+	<key>CFBundleVersion</key>
+	<string>4.2.3</string>
 	<key>CFBundleShortVersionString</key>
 	<string>4.2.3</string>
 	<key>CFBundleSignature</key>
@@ -33,5 +35,7 @@
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	<key>SUFeedURL</key>
+	<string>http://seafile.com/appcast/stable.xml</string>
 </dict>
 </plist>

--- a/scripts/build_helper.py
+++ b/scripts/build_helper.py
@@ -116,6 +116,12 @@ def write_output(command):
     proc = subprocess.Popen(command, stdout=_output, stderr=_output, shell=False)
     proc.communicate()
 
+def write_output_regardless(command):
+    try:
+        write_output(command)
+    except subprocess.CalledProcessError:
+        _output.write('command "%s" failed' % command)
+
 if __name__ == '__main__':
     if (len(sys.argv) < 2):
         print 'Usage: %s <input-file>' % sys.argv[0]

--- a/scripts/stable.xml.sample
+++ b/scripts/stable.xml.sample
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Seafile Client Changelog</title>
+    <link>http://seafile.com/appcast/stable.xml</link>
+    <description>Most recent changes with links to updates.</description>
+    <language>en</language>
+
+    <item>
+      <title>Version 4.1.3</title>
+      <sparkle:releaseNotesLink>http://seacloud.cc/group/3/wiki/client-changelog/#41</sparkle:releaseNotesLink>
+      <sparkle:releaseNotesLink xml:lang="de">https://www.seafile-server.org/seafile-client-4-1-3-veroeffentlicht-ersetzt-4-1-2/</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>10.7.0</sparkle:minimumSystemVersion>
+      <pubDate>Wed, 08 Apr 2015 02:17:38 -0000</pubDate>
+      <enclosure url="https://bitbucket.org/haiwen/seafile/downloads/seafile-client-4.1.3.dmg" sparkle:version="4.1.3" length="14936939" type="application/octet-stream" />
+      <enclosure xml:lang="zhCN" url="http://download-cn.seafile.com/seafile-client-4.1.3.dmg" sparkle:version="4.1.3" length="14936939" type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>

--- a/src/seafile-applet.cpp
+++ b/src/seafile-applet.cpp
@@ -45,6 +45,10 @@
 #include "finder-sync/finder-sync-listener.h"
 #endif
 
+#if defined(HAVE_SPARKLE_SUPPORT)
+#include "sparkle-support.h"
+#endif // HAVE_SPARKLE_SUPPORT
+
 #include "seafile-applet.h"
 
 namespace {
@@ -527,8 +531,10 @@ bool SeafileApplet::detailedYesOrNoBox(const QString& msg, const QString& detail
     return msgBox.exec() == QMessageBox::Yes;
 }
 
-void SeafileApplet::checkLatestVersionInfo()
+void SeafileApplet::checkLatestVersionInfo(bool force)
 {
+#ifndef HAVE_SPARKLE_SUPPORT
+    Q_UNUSED(force)
     QString id = rpc_client_->getCcnetPeerId();
     QString version = STRINGIZE(SEAFILE_CLIENT_VERSION);
 
@@ -537,6 +543,9 @@ void SeafileApplet::checkLatestVersionInfo()
 
     connect(req, SIGNAL(success(const QString&)),
             this, SLOT(onGetLatestVersionInfoSuccess(const QString&)));
+#else
+    SparkleHelper::checkForUpdate(force);
+#endif
 }
 
 void SeafileApplet::onGetLatestVersionInfoSuccess(const QString& latest_version)

--- a/src/seafile-applet.h
+++ b/src/seafile-applet.h
@@ -60,6 +60,8 @@ public:
     bool started() { return started_; }
     bool inExit() { return in_exit_; }
 
+    void checkLatestVersionInfo(bool force = false);
+
 private slots:
     void onDaemonStarted();
     void checkInitVDrive();
@@ -73,8 +75,6 @@ private:
     void initLog();
 
     bool loadQss(const QString& path);
-
-    void checkLatestVersionInfo();
 
     Configurator *configurator_;
 

--- a/src/settings-mgr.cpp
+++ b/src/settings-mgr.cpp
@@ -19,6 +19,10 @@
 #include "finder-sync/finder-sync.h"
 #endif
 
+#if defined(HAVE_SPARKLE_SUPPORT)
+#include "sparkle-support.h"
+#endif
+
 namespace {
 
 const char *kHideMainWindowWhenStarted = "hideMainWindowWhenStarted";
@@ -306,6 +310,10 @@ void SettingsManager::setCheckLatestVersionEnabled(bool enabled)
     settings.beginGroup(kBehaviorGroup);
     settings.setValue(kCheckLatestVersion, enabled);
     settings.endGroup();
+
+#if defined(HAVE_SPARKLE_SUPPORT)
+    SparkleHelper::setAutomaticallyChecksForUpdates(enabled);
+#endif
 }
 
 bool SettingsManager::isCheckLatestVersionEnabled()
@@ -322,6 +330,10 @@ bool SettingsManager::isCheckLatestVersionEnabled()
     settings.beginGroup(kBehaviorGroup);
     enabled = settings.value(kCheckLatestVersion, true).toBool();
     settings.endGroup();
+
+#if defined(HAVE_SPARKLE_SUPPORT)
+    SparkleHelper::setAutomaticallyChecksForUpdates(enabled);
+#endif
 
     return enabled;
 }

--- a/src/sparkle-support.h
+++ b/src/sparkle-support.h
@@ -1,0 +1,10 @@
+#ifndef SEAFILE_CLIENT_SPARKLE_SUPPORT_H
+#define SEAFILE_CLIENT_SPARKLE_SUPPORT_H
+
+class SparkleHelper {
+public:
+    static void checkForUpdate(bool force = false);
+    static void setAutomaticallyChecksForUpdates(bool enabled);
+};
+
+#endif // SEAFILE_CLIENT_SPARKLE_SUPPORT_H

--- a/src/sparkle-support.mm
+++ b/src/sparkle-support.mm
@@ -1,0 +1,15 @@
+#include "sparkle-support.h"
+
+#import "SUUpdater.h"
+
+void SparkleHelper::checkForUpdate(bool force)
+{
+    if (force || [[SUUpdater sharedUpdater] automaticallyChecksForUpdates])
+        [[SUUpdater sharedUpdater] checkForUpdatesInBackground];
+}
+
+void SparkleHelper::setAutomaticallyChecksForUpdates(bool enabled)
+{
+    [[SUUpdater sharedUpdater] setAutomaticallyChecksForUpdates: enabled];
+    [[SUUpdater sharedUpdater] setAutomaticallyDownloadsUpdates: enabled];
+}

--- a/src/ui/tray-icon.cpp
+++ b/src/ui/tray-icon.cpp
@@ -112,6 +112,10 @@ void SeafileTrayIcon::createActions()
     connect(view_unread_seahub_notifications_action_, SIGNAL(triggered()),
             this, SLOT(viewUnreadNotifications()));
 
+    check_for_latest_version_action_ = new QAction(tr("Check for latest version"), this);
+    connect(check_for_latest_version_action_, SIGNAL(triggered()),
+            this, SLOT(checkLatestVersionInfo()));
+
     quit_action_ = new QAction(tr("&Quit"), this);
     connect(quit_action_, SIGNAL(triggered()), this, SLOT(quitSeafile()));
 
@@ -145,6 +149,7 @@ void SeafileTrayIcon::createContextMenu()
     context_menu_->addAction(show_main_window_action_);
     context_menu_->addAction(settings_action_);
     context_menu_->addAction(open_log_directory_action_);
+    context_menu_->addAction(check_for_latest_version_action_);
     context_menu_->addMenu(help_menu_);
     context_menu_->addSeparator();
     context_menu_->addAction(enable_auto_sync_action_);
@@ -177,6 +182,7 @@ void SeafileTrayIcon::createGlobalMenuBar()
     // create qmenu used in menubar and docker menu
     global_menu_ = new QMenu(tr("File"));
     global_menu_->addAction(view_unread_seahub_notifications_action_);
+    global_menu_->addAction(check_for_latest_version_action_);
     global_menu_->addAction(show_main_window_action_);
     global_menu_->addAction(settings_action_);
     global_menu_->addAction(open_log_directory_action_);
@@ -545,4 +551,9 @@ void SeafileTrayIcon::onMessageClicked()
         !repo.isValid() || repo.worktree_invalid)
         return;
     showInGraphicalShell(repo.worktree);
+}
+
+void SeafileTrayIcon::checkLatestVersionInfo()
+{
+    seafApplet->checkLatestVersionInfo();
 }

--- a/src/ui/tray-icon.h
+++ b/src/ui/tray-icon.h
@@ -56,6 +56,7 @@ private slots:
     void about();
     void onSeahubNotificationsChanged();
     void viewUnreadNotifications();
+    void checkLatestVersionInfo();
 
     // only used on windows
     void onMessageClicked();
@@ -84,6 +85,7 @@ private:
     QAction *settings_action_;
     QAction *open_log_directory_action_;
     QAction *view_unread_seahub_notifications_action_;
+    QAction *check_for_latest_version_action_;
 
     QAction *about_action_;
     QAction *open_help_action_;


### PR DESCRIPTION
[Sparkle](http://sparkle-project.org/) is a opensource software update framework (OSX).
Adding support of Sparkle will make it ease to update seafile-client by simply one-click.

This PR quite is plain but useful to kinds of our users. 

still missing:
- appcast xml generator (xml example: https://trello-attachments.s3.amazonaws.com/53e0eadf77f38b8026f922fa/551a30849583d93262bd3c26/68c0f54073d919c9506097bc80d9a1d4/GitX-dev.xml)
- upload the xml to the seafile.com website (feed url: seafile.com/appcast/stable.xml)
