### PR TITLE
don't show native title bar on linux

### DIFF
--- a/src/ui/main-window.cpp
+++ b/src/ui/main-window.cpp
@@ -77,8 +77,7 @@ MainWindow::MainWindow()
 #if !defined(Q_OS_MAC)
                    | Qt::FramelessWindowHint
 #endif
-                   | Qt::WindowSystemMenuHint
-                   | Qt::WindowMinimizeButtonHint);
+                   | Qt::WindowSystemMenuHint);
 
     cloud_view_ = new CloudView;
 


### PR DESCRIPTION
tested under OSX 10.10, Windows 7, Ubuntu 12.04, and Debian Jessie