### PR TITLE
fix the memory leak every time the repo item menu is popped

### DIFF
--- a/src/ui/repo-tree-view.cpp
+++ b/src/ui/repo-tree-view.cpp
@@ -176,6 +176,7 @@ void RepoTreeView::contextMenuEvent(QContextMenuEvent *event)
     QMenu *menu = prepareContextMenu((RepoItem *)item);
     pos = viewport()->mapToGlobal(pos);
     menu->exec(pos);
+    menu->deleteLater();
 }
 
 QMenu* RepoTreeView::prepareContextMenu(const RepoItem *item)


### PR DESCRIPTION
- this will recover approx. 2KiB memory every time