### PR TITLE
filebrowser: fix some ui bugs on windows 8

### DIFF
--- a/qt.css
+++ b/qt.css
@@ -408,6 +408,10 @@ FileBrowserDialog {
     min-height: 456px;
 }
 
+FileBrowserDialog QSizeGrip {
+    margin-right: 2px;
+}
+
 FileBrowserDialog QWidget#mainWidget {
     border: 1px solid #333;
     border-radius: 5px;

--- a/src/filebrowser/file-browser-dialog.cpp
+++ b/src/filebrowser/file-browser-dialog.cpp
@@ -1022,6 +1022,12 @@ bool FileBrowserDialog::eventFilter(QObject *obj, QEvent *event)
     return QDialog::eventFilter(obj, event);
 }
 
+void FileBrowserDialog::resizeEvent(QResizeEvent *event)
+{
+    resizer_->move(rect().bottomRight() - resizer_->rect().bottomRight());
+    resizer_->raise();
+}
+
 void FileBrowserDialog::closeEvent(QCloseEvent *event)
 {
     emit aboutToClose();

--- a/src/filebrowser/file-browser-dialog.h
+++ b/src/filebrowser/file-browser-dialog.h
@@ -111,6 +111,7 @@ private:
 
     bool eventFilter(QObject *obj, QEvent *event);
     void closeEvent(QCloseEvent *event);
+    void resizeEvent(QResizeEvent *event);
     void reject();
     bool hasFilesToBePasted();
     void setFilesToBePasted(bool is_copy, const QStringList &file_names);

--- a/src/filebrowser/file-table.cpp
+++ b/src/filebrowser/file-table.cpp
@@ -35,7 +35,8 @@ const int kDefaultColumnWidth = 120;
 const int kDefaultColumnHeight = 40;
 const int kColumnIconSize = 28;
 const int kFileNameColumnWidth = 200;
-const int kDefaultColumnSum = kFileNameColumnWidth + kDefaultColumnWidth * 3;
+const int kExtraPadding = 30;
+const int kDefaultColumnSum = kFileNameColumnWidth + kDefaultColumnWidth * 3 + kExtraPadding;
 
 const int kRefreshProgressInterval = 1000;
 


### PR DESCRIPTION
Closes #530.

- show size resizer correctly (on windows8)
- calculate the width correctly (on windows8)