### PR TITLE
require a refresh once repo tab is shown

### DIFF
--- a/src/ui/repos-tab.cpp
+++ b/src/ui/repos-tab.cpp
@@ -149,6 +149,7 @@ void ReposTab::refresh()
 void ReposTab::startRefresh()
 {
     RepoService::instance()->start();
+    RepoService::instance()->refresh(true);
 }
 
 void ReposTab::stopRefresh()


### PR DESCRIPTION
fix a issue sycned subfolders are not shown when client starts