### PR TITLE
avoid data race when quiting

### DIFF
--- a/src/api/api-client.cpp
+++ b/src/api/api-client.cpp
@@ -35,8 +35,8 @@ SeafileApiClient::SeafileApiClient(QObject *parent)
       redirect_count_(0)
 {
     if (!na_mgr_) {
-        static QNetworkAccessManager mNetworkAccessManager;
-        na_mgr_ = &mNetworkAccessManager;
+        static QNetworkAccessManager *manager = new QNetworkAccessManager(qApp);
+        na_mgr_ = manager;
         NetworkManager::instance()->addWatch(na_mgr_);
     }
 }

--- a/src/filebrowser/tasks.cpp
+++ b/src/filebrowser/tasks.cpp
@@ -12,6 +12,7 @@
 #include <QSslCertificate>
 #include <QDirIterator>
 #include <QTimer>
+#include <QApplication>
 
 #include "utils/utils.h"
 #include "utils/file-utils.h"
@@ -404,8 +405,8 @@ void GetFileTask::sendRequest()
 {
     QNetworkRequest request(url_);
     if (!network_mgr_) {
-        static QNetworkAccessManager manager;
-        network_mgr_ = &manager;
+        static QNetworkAccessManager *manager = new QNetworkAccessManager(qApp);
+        network_mgr_ = manager;
         NetworkManager::instance()->addWatch(network_mgr_);
     }
     reply_ = network_mgr_->get(request);
@@ -554,8 +555,8 @@ void PostFileTask::sendRequest()
     request.setRawHeader("Content-Type",
                          "multipart/form-data; boundary=" + multipart->boundary());
     if (!network_mgr_) {
-        static QNetworkAccessManager manager;
-        network_mgr_ = &manager;
+        static QNetworkAccessManager *manager = new QNetworkAccessManager(qApp);
+        network_mgr_ = manager;
         NetworkManager::instance()->addWatch(network_mgr_);
     }
     reply_ = network_mgr_->post(request, multipart);


### PR DESCRIPTION
global objects are destoryed after qApp destruction, which is not too good and
causes data race between threads. this patch should fix this issue.