### PR TITLE
file browser auto update cached files: fixed a bug when file recreated

### DIFF
--- a/src/filebrowser/auto-update-mgr.cpp
+++ b/src/filebrowser/auto-update-mgr.cpp
@@ -149,6 +149,9 @@ void AutoUpdateManager::checkFileRecreated()
         qDebug("file %s recreated", toCStr(info.path_in_repo));
         watcher_.addPath(path);
         watch_infos_[path] = info;
+        // Some applications like MSOffice would remove the original file and
+        // recreate it when the user modifies the file.
+        onFileChanged(path);
     }
 }
 


### PR DESCRIPTION
Some applications like MSOffice would remove the original file and recreate it when the user modifies the file, for example:

- User modifies an xls file
- Excel deletes the original file
- Excel recreates the xls file with the modified content

In this situation, we should upload the newly recreated file.