### PR TITLE
[win] Prefer global server configuration through HKLM

### DIFF
--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -34,7 +34,7 @@ const char *kMyComputerNamespacePath =
 const char* const kPreconfigureDirectory = "PreconfigureDirectory";
 QString getPreconfigureDirectory()
 {
-    RegElement reg(HKEY_CURRENT_USER, "SOFTWARE\\Seafile", kPreconfigureDirectory, "");
+    RegElement reg(HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", kPreconfigureDirectory, "");
     if (!reg.exists()) {
         return QString();
     }

--- a/src/ui/login-dialog.cpp
+++ b/src/ui/login-dialog.cpp
@@ -34,7 +34,7 @@ const char *kUsedServerAddresses = "UsedServerAddresses";
 const char *const kPreconfigureServerAddr = "PreconfigureServerAddr";
 const char *const kPreconfigureServerAddrOnly = "PreconfigureServerAddrOnly";
 QString getPreconfigureServerAddr() {
-    RegElement reg(HKEY_CURRENT_USER, "SOFTWARE\\Seafile", kPreconfigureServerAddr,
+    RegElement reg(HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", kPreconfigureServerAddr,
                    "");
     if (!reg.exists()) {
         return QString();
@@ -43,7 +43,7 @@ QString getPreconfigureServerAddr() {
     return reg.stringValue();
 }
 int getPreconfigureServerAddrOnly() {
-    RegElement reg(HKEY_CURRENT_USER, "SOFTWARE\\Seafile", kPreconfigureServerAddrOnly,
+    RegElement reg(HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", kPreconfigureServerAddrOnly,
                    "");
     if (!reg.exists()) {
         return 0;

--- a/src/utils/registry.cpp
+++ b/src/utils/registry.cpp
@@ -8,13 +8,13 @@
 
 namespace {
 
-LONG openKey(HKEY root, const QString& path, HKEY *p_key)
+LONG openKey(HKEY root, const QString& path, HKEY *p_key, REGSAM samDesired = KEY_ALL_ACCESS)
 {
     LONG result;
     result = RegOpenKeyExW(root,
                            path.toStdWString().c_str(),
                            0L,
-                           KEY_ALL_ACCESS,
+                           samDesired,
                            p_key);
 
     return result;
@@ -123,7 +123,7 @@ int RegElement::removeRegKey(HKEY root, const QString& path, const QString& subk
 bool RegElement::exists()
 {
     HKEY parent_key;
-    LONG result = openKey(root_, path_, &parent_key);
+    LONG result = openKey(root_, path_, &parent_key, KEY_READ);
     if (result != ERROR_SUCCESS) {
         return false;
     }
@@ -150,7 +150,7 @@ void RegElement::read()
     string_value_.clear();
     dword_value_ = 0;
     HKEY parent_key;
-    LONG result = openKey(root_, path_, &parent_key);
+    LONG result = openKey(root_, path_, &parent_key, KEY_READ);
     if (result != ERROR_SUCCESS) {
         return;
     }
@@ -234,7 +234,7 @@ void RegElement::read()
 void RegElement::remove()
 {
     HKEY parent_key;
-    LONG result = openKey(root_, path_, &parent_key);
+    LONG result = openKey(root_, path_, &parent_key, KEY_ALL_ACCESS);
     if (result != ERROR_SUCCESS) {
         return;
     }


### PR DESCRIPTION
HKCU can be used only for current logged-in user. 
HKLM will be easier because the settings will apply to all users globally, for new connected users or users which have already logged onto the workstation once
