### PR TITLE
refactor the code of reading pre-configured values

### DIFF
--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -34,12 +34,7 @@ const char *kMyComputerNamespacePath =
 const char* const kPreconfigureDirectory = "PreconfigureDirectory";
 QString getPreconfigureDirectory()
 {
-    RegElement reg(HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", kPreconfigureDirectory, "");
-    if (!reg.exists()) {
-        return QString();
-    }
-    reg.read();
-    return reg.stringValue();
+    return RegElement::getPreconfigureStringValue(kPreconfigureDirectory);
 }
 #endif
 

--- a/src/ui/login-dialog.cpp
+++ b/src/ui/login-dialog.cpp
@@ -34,26 +34,10 @@ const char *kUsedServerAddresses = "UsedServerAddresses";
 const char *const kPreconfigureServerAddr = "PreconfigureServerAddr";
 const char *const kPreconfigureServerAddrOnly = "PreconfigureServerAddrOnly";
 QString getPreconfigureServerAddr() {
-    RegElement reg(HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", kPreconfigureServerAddr,
-                   "");
-    if (!reg.exists()) {
-        return QString();
-    }
-    reg.read();
-    return reg.stringValue();
+    return RegElement::getPreconfigureStringValue(kPreconfigureServerAddr);
 }
 int getPreconfigureServerAddrOnly() {
-    RegElement reg(HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", kPreconfigureServerAddrOnly,
-                   "");
-    if (!reg.exists()) {
-        return 0;
-    }
-    reg.read();
-
-    if (!reg.stringValue().isEmpty())
-        return reg.stringValue().toInt();
-
-    return reg.dwordValue();
+    return RegElement::getPreconfigureIntValue(kPreconfigureServerAddrOnly);
 }
 #endif
 QStringList getUsedServerAddresses()

--- a/src/utils/registry.cpp
+++ b/src/utils/registry.cpp
@@ -276,5 +276,38 @@ int RegElement::getPreconfigureIntValue(const QString& name)
     }
 
     return RegElement::getIntValue(
-        HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", name, NULL, 0);
+        HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", name);
+}
+
+QString RegElement::getStringValue(HKEY root,
+                                   const QString& path,
+                                   const QString& name,
+                                   bool *exists,
+                                   QString default_val)
+{
+    RegElement reg(root, path, name, "");
+    if (!reg.exists()) {
+        if (exists) {
+            *exists = false;
+        }
+        return default_val;
+    }
+    if (exists) {
+        *exists = true;
+    }
+    reg.read();
+    return reg.stringValue();
+}
+
+QString RegElement::getPreconfigureStringValue(const QString& name)
+{
+    bool exists;
+    QString ret = getStringValue(
+        HKEY_CURRENT_USER, "SOFTWARE\\Seafile", name, &exists);
+    if (exists) {
+        return ret;
+    }
+
+    return RegElement::getStringValue(
+        HKEY_LOCAL_MACHINE, "SOFTWARE\\Seafile", name);
 }

--- a/src/utils/registry.h
+++ b/src/utils/registry.h
@@ -44,8 +44,10 @@ public:
 public:
     static int removeRegKey(HKEY root, const QString& path, const QString& subkey);
     static int getIntValue(HKEY root, const QString& path, const QString& name, bool *exists=NULL, int default_val=0);
+    static QString getStringValue(HKEY root, const QString& path, const QString& name, bool *exists=NULL, QString default_val=QString());
 
     static int getPreconfigureIntValue(const QString& name);
+    static QString getPreconfigureStringValue(const QString& name);
 
 private:
 


### PR DESCRIPTION
For values like `PreconfigureServerAddr`, seafile applet would first try to read it from `HKEY_CURRENT_USER\Software\Seafile\PreconfigureServerAddr` (per-user settings), and fallback to `HKEY_LOCAL_MACHINE\Software\Seafile\PreconfigureServerAddr` (global settings) if not found in the per-user registry.