### PR TITLE
fixed concurrent access to accounts manager from extension handlers

### DIFF
--- a/src/account-mgr.h
+++ b/src/account-mgr.h
@@ -5,12 +5,14 @@
 
 #include <QObject>
 #include <QHash>
+#include <QMutex>
 
 #include "account.h"
 
 struct sqlite3;
 struct sqlite3_stmt;
 class ApiError;
+class SeafileRpcClient;
 
 /**
  * Load/Save seahub accounts
@@ -51,6 +53,9 @@ public:
     /// return an invalid Account if failed
     Account getAccountByRepo(const QString& repo_id);
 
+    // Also used by extension handler
+    Account getAccountByRepo(const QString& repo_id, SeafileRpcClient *rpc);
+
     // accessors
     const std::vector<Account>& accounts() const { return accounts_; }
 
@@ -85,6 +90,9 @@ private:
 
     struct sqlite3 *db;
     std::vector<Account> accounts_;
+
+    QMutex accounts_mutex_;
+    QMutex accounts_cache_mutex_;
 };
 
 #endif  // _SEAF_ACCOUNT_MGR_H

--- a/src/ext-handler.cpp
+++ b/src/ext-handler.cpp
@@ -489,7 +489,7 @@ QList<LocalRepo> ReposInfoCache::getReposInfo(quint64 ts)
     for (size_t i = 0; i < repos.size(); i++) {
         LocalRepo& repo = repos[i];
         rpc_->getSyncStatus(repo);
-        repo.account = seafApplet->accountManager()->getAccountByRepo(repo.id);
+        repo.account = seafApplet->accountManager()->getAccountByRepo(repo.id, rpc_);
     }
 
     cached_info_ = QVector<LocalRepo>::fromStdVector(repos).toList();


### PR DESCRIPTION
- Fixed the mistake of using the main thread's rpc client in `AccountManager::getAccountByRepo` in extension code
- Protect account manager data with locks when modifying them

