### PR TITLE
fixed "drop here" text displaying when focused

### DIFF
--- a/qt.css
+++ b/qt.css
@@ -163,6 +163,7 @@ CloudView QPushButton#mSelectFolderBtn:hover {
 CloudView QLabel#mDropFolderText {
     color: #525252;
     font-size: 16px;
+    margin-left: 3px;
 }
 
 CloudView QFrame#mFooter {

--- a/qt.css
+++ b/qt.css
@@ -154,6 +154,7 @@ CloudView QPushButton#mSelectFolderBtn {
 }
 
 CloudView QPushButton#mSelectFolderBtn:hover {
+    font-size: 15px;
     font-weight: bold;
     background: #DBDBDC;
     border-radius: 5px;

--- a/ui/cloud-view.ui
+++ b/ui/cloud-view.ui
@@ -20,7 +20,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -157,6 +166,12 @@
            </item>
            <item>
             <widget class="QPushButton" name="mSelectFolderBtn">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="text">
               <string>Select</string>
              </property>


### PR DESCRIPTION
Germany:

<img width="269" alt="screen shot 2015-09-08 at 17 53 20" src="https://cloud.githubusercontent.com/assets/717363/9731924/9f1526ae-5652-11e5-87d7-9bbc32a2dd10.png">

Chinese:

<img width="320" alt="screen shot 2015-09-08 at 17 52 11" src="https://cloud.githubusercontent.com/assets/717363/9731928/a16645b4-5652-11e5-8f53-dceda430a739.png">

English: 
<img width="256" alt="screen shot 2015-09-08 at 17 53 54" src="https://cloud.githubusercontent.com/assets/717363/9731932/a85d82d8-5652-11e5-927e-02c9418956cf.png">
