### PR TITLE
Client certificate

### DIFF
--- a/src/api/api-client.h
+++ b/src/api/api-client.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QObject>
 #include <QNetworkReply>
+#include <QSslConfiguration>
 
 #include "account.h"
 #include "server-repo.h"
@@ -42,6 +43,8 @@ private:
 
     void resendRequest(const QUrl& url);
 
+    void InitSslConfiguration(const QUrl& url);
+
     static QNetworkAccessManager *na_mgr_;
 
     QString token_;
@@ -49,6 +52,8 @@ private:
     QByteArray body_;
 
     QNetworkReply *reply_;
+
+    QSslConfiguration ssl_config_;
 
     int redirect_count_;
 };


### PR DESCRIPTION
This is what've done to handle client certificate, it might help you.  

When connecting to _https://host.com/files_ client certificate and private key will be loaded from _~/.ccnet/host.com.pem_ and _~/.ccnet/host.com.key_.  

It's not working with Ubuntu 14.04 which rely on Qt 5.2. See [QTBUG-7200](https://bugreports.qt.io/browse/QTBUG-7200?jql=text%20~%20%22setLocalCertificate%22).  
