### PR TITLE
tray-icon.cpp: do not rotation tray icon on Gnome to improve user experience (no more tray bar show/hide toggles)

### DIFF
--- a/src/ui/tray-icon.cpp
+++ b/src/ui/tray-icon.cpp
@@ -212,6 +212,12 @@ void SeafileTrayIcon::createGlobalMenuBar()
 
 void SeafileTrayIcon::rotate(bool start)
 {
+    /* tray icon should not be refreshed on Gnome according to their guidelines */
+    const char *env = g_getenv("DESKTOP_SESSION");
+    if (env && strcmp(env, "gnome") == 0) {
+        return;
+    }
+
     if (start) {
         rotate_counter_ = 0;
         if (!rotate_timer_->isActive()) {


### PR DESCRIPTION
Fixing issue #721.