### PR TITLE
Client send notification file conflict for user email.

### DIFF
--- a/src/api/requests.cpp
+++ b/src/api/requests.cpp
@@ -42,6 +42,7 @@ const char* kFileSearchUrl = "api2/search/";
 const char* kAccountInfoUrl = "api2/account/info/";
 const char* kDirSharedItemsUrl = "api2/repos/%1/dir/shared_items/";
 const char* kFetchGroupsAndContactsUrl = "api2/groupandcontacts/";
+const char* kSendNotifyFileConflict = "api2/send-notify-file-conflict/";
 
 const char* kLatestVersionUrl = "https://seafile.com/api/client-versions/";
 
@@ -1064,3 +1065,25 @@ void GetPrivateShareItemsRequest::requestSuccess(QNetworkReply& reply)
 
     emit success(group_shares, user_shares);
 }
+
+/**
+ * SendNotifyFileConflictRequest
+ */
+SendNotifyFileConflictRequest::SendNotifyFileConflictRequest(
+    const Account& account, const QString& repo_id, const QString& repo_name, QString& path)
+    : SeafileApiRequest(account.getAbsoluteUrl(kSendNotifyFileConflict),
+                        SeafileApiRequest::METHOD_POST,
+                        account.token)
+{
+
+    setFormParam("repo_id", repo_id);
+    setFormParam("repo_name", repo_name);
+    setFormParam("path", path);
+
+}
+
+void SendNotifyFileConflictRequest::requestSuccess(QNetworkReply& reply)
+{
+	emit success();
+}
+

--- a/src/api/requests.h
+++ b/src/api/requests.h
@@ -640,4 +640,24 @@ private:
     Q_DISABLE_COPY(FetchGroupsAndContactsRequest);
 };
 
+class SendNotifyFileConflictRequest : public SeafileApiRequest
+{
+    Q_OBJECT
+
+public:
+    explicit SendNotifyFileConflictRequest(const Account& account,
+    		const QString& repo_id,
+    		const QString& repo_name,
+    		QString& path);
+
+protected slots:
+    void requestSuccess(QNetworkReply& reply);
+
+signals:
+    void success();
+
+private:
+    Q_DISABLE_COPY(SendNotifyFileConflictRequest)
+};
+
 #endif // SEAFILE_CLIENT_API_REQUESTS_H

--- a/src/message-listener.cpp
+++ b/src/message-listener.cpp
@@ -17,6 +17,8 @@ extern "C" {
 #include "utils/utils.h"
 #include "utils/translate-commit-desc.h"
 #include "open-local-helper.h"
+#include "api/requests.h"
+#include "account-mgr.h"
 
 #include "message-listener.h"
 
@@ -187,6 +189,12 @@ void MessageListener::handleMessage(CcnetMessage *message)
             QString msg = tr("File %1 conflict").arg(path);
 
             seafApplet->trayIcon()->showMessage(title, msg, repo_id);
+
+            Account account = seafApplet->accountManager()->currentAccount();
+
+            SendNotifyFileConflictRequest *send_notify_file_conflict = new SendNotifyFileConflictRequest(account, repo_id, title, path);
+
+            send_notify_file_conflict->send();
 
             json_decref(object);
         } else if (strcmp(type, "sync.error") == 0) {


### PR DESCRIPTION
Client send notification file conflict for user email.
client->api seahub->email

using seahub api:
https://github.com/haiwen/seahub/pull/1104

On branch feature/client-send_notify_file_conflict
Changes to be committed:
    modified:   src/api/requests.cpp
    modified:   src/api/requests.h
    modified:   src/message-listener.cpp
