### PR TITLE
Regression fix for StatusNotifierItem protocol

### DIFF
--- a/src/ui/tray-icon.cpp
+++ b/src/ui/tray-icon.cpp
@@ -355,14 +355,6 @@ void SeafileTrayIcon::setState(TrayState state, const QString& tip)
     QString tool_tip = tip.isEmpty() ? getBrand() : tip;
 
     setIcon(stateToIcon(state));
-
-    // the following two lines solving the problem of tray icon
-    // disappear in ubuntu 13.04
-#if defined(Q_OS_LINUX)
-    hide();
-    show();
-#endif
-
     setToolTip(tool_tip);
 }
 


### PR DESCRIPTION
The removed lines were causing a problem for the context menu to not work with qt5.6 which uses DBus, SNI and the com.canonical.dbusmenu interface. Apparently this cannot just be related to seafile but the hide() and immediately following show() call  somehow caused the Menubar object of the StatusNotifierItem to 'disappear' effectively removing the dbus  context menu object.