### PR TITLE
When the size of uploading file is larger than 2G,the progress bar do not work

### DIFF
--- a/i18n/seafile_zh_CN.ts
+++ b/i18n/seafile_zh_CN.ts
@@ -9,7 +9,7 @@
     <message>
         <location filename="../src/account-mgr.cpp" line="538"/>
         <source>Authorization expired, please re-login</source>
-        <translation>账号验证信息已过期，请重现登录</translation>
+        <translation>账号验证信息已过期，请重新登录</translation>
     </message>
 </context>
 <context>

--- a/src/filebrowser/progress-dialog.cpp
+++ b/src/filebrowser/progress-dialog.cpp
@@ -81,11 +81,9 @@ void FileBrowserProgressDialog::onProgressUpdate(qint64 processed_bytes, qint64 
     if (processed_bytes >= total_bytes)
         total_bytes = processed_bytes + 1;
 
-	if (maximum() != 100)
-    {
-		setMaximum(100);
-    }
-	setValue ((int)((double)processed_bytes/total_bytes*100));
+    if (maximum() != 100)
+        setMaximum(100);
+    setValue ((int)((double)processed_bytes/total_bytes*100));
 
     more_details_label_->setText(tr("%1 of %2")
                             .arg(::readableFileSizeV2(processed_bytes))

--- a/src/filebrowser/progress-dialog.cpp
+++ b/src/filebrowser/progress-dialog.cpp
@@ -81,10 +81,11 @@ void FileBrowserProgressDialog::onProgressUpdate(qint64 processed_bytes, qint64 
     if (processed_bytes >= total_bytes)
         total_bytes = processed_bytes + 1;
 
-    if (maximum() != total_bytes)
-        setMaximum(total_bytes);
-
-    setValue(processed_bytes);
+	if (maximum() != 100)
+    {
+		setMaximum(100);
+    }
+	setValue ((int)((double)processed_bytes/total_bytes*100));
 
     more_details_label_->setText(tr("%1 of %2")
                             .arg(::readableFileSizeV2(processed_bytes))


### PR DESCRIPTION
Prototype:
void    QProgressDialog::setMaximum(int maximum);
void    QProgressDialog::setValue(int progress);

void FileBrowserProgressDialog::onProgressUpdate(qint64 processed_bytes, qint64 total_bytes)

'total_bytes' and 'processed_bytes' can be larger than 2147483648(2G).
