### PR TITLE
Don't use QT5.6 autoscaling on Linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,7 @@ void setupHIDPIFix()
     qApp->setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && !defined(Q_OS_MAC)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && defined(Q_OS_WIN)
     // Enable HDPI auto detection.
     // See http://blog.qt.io/blog/2016/01/26/high-dpi-support-in-qt-5-6/
     qApp->setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
The autoscaling feature since Qt 5.6 applies a 2x scaling at >144 DPI. This affects not just users with real hiDPI displays since a display with a fullhd resolution and a <=15.2" size has a greater DPI than the default threshold. Because of the fact that e.g. GNOME starts scaling at 192 DPI and everything below needs to be done manually it's much saner to disable the autoscale feature until more people own a real hiDPI display. This should 'fix' #809 for now.