### PR TITLE
Fixed QVariant is ambiguous - appears on Arch

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -468,7 +468,7 @@ QList<QVariant> listFromJSON(json_t *array)
         } else if (json_is_string(value)) {
             v = QString::fromUtf8(json_string_value(value));
         } else if (json_is_integer(value)) {
-            v = json_integer_value(value);
+            v = QVariant::fromValue(json_integer_value(value));
         } else if (json_is_real(value)) {
             v = json_real_value(value);
         } else if (json_is_boolean(value)) {
@@ -510,7 +510,7 @@ QMap<QString, QVariant> mapFromJSON(json_t *json, json_error_t *error)
         } else if (json_is_string(value)) {
             v = QString::fromUtf8(json_string_value(value));
         } else if (json_is_integer(value)) {
-            v = json_integer_value(value);
+            v = QVariant::fromValue(json_integer_value(value));
         } else if (json_is_real(value)) {
             v = json_real_value(value);
         } else if (json_is_boolean(value)) {


### PR DESCRIPTION
The error was
error: conversion from ‘int64_t {aka long int}’ to ‘QVariant’ is ambiguous