### PR TITLE
Added class CachedFilesCleaner to delete .seafile-data/file-cache dir.

### DIFF
--- a/src/filebrowser/auto-update-mgr.h
+++ b/src/filebrowser/auto-update-mgr.h
@@ -20,6 +20,7 @@ public:
     void watchCachedFile(const Account& account,
                          const QString& repo_id,
                          const QString& path);
+    void cleanCachedFile();
 
 signals:
     void fileUpdated(const QString& repo_id, const QString& path);
@@ -81,11 +82,6 @@ public:
     bool autoDelete() {
         return true;
     }
-
-private:
-    QString file_cache_dir_;
-    QString file_cache_tmp_dir_;
-    QString file_cache_db_file_;
 };
 
 #endif // SEAFILE_CLIENT_FILE_BROWSER_AUTO_UPDATE_MANAGER_H

--- a/src/filebrowser/auto-update-mgr.h
+++ b/src/filebrowser/auto-update-mgr.h
@@ -4,6 +4,7 @@
 #include <QFileSystemWatcher>
 #include <QHash>
 #include <QQueue>
+#include <QRunnable>
 
 #include "utils/singleton.h"
 #include "account.h"
@@ -71,5 +72,20 @@ private:
     QHash<QString, qint64> images_;
 };
 #endif // Q_OS_MAC
+
+class CachedFilesCleaner : public QObject, public QRunnable {
+    Q_OBJECT
+public:
+    CachedFilesCleaner();
+    void run();
+    bool autoDelete() {
+        return true;
+    }
+
+private:
+    QString file_cache_dir_;
+    QString file_cache_tmp_dir_;
+    QString file_cache_db_file_;
+};
 
 #endif // SEAFILE_CLIENT_FILE_BROWSER_AUTO_UPDATE_MANAGER_H

--- a/src/filebrowser/data-cache.h
+++ b/src/filebrowser/data-cache.h
@@ -45,8 +45,8 @@ private:
  * Record the file id of downloaded files.
  * The schema is (repo_id, path, downloaded_file_id)
  */
-class FileCacheDB {
-    SINGLETON_DEFINE(FileCacheDB)
+class FileCache {
+    SINGLETON_DEFINE(FileCache)
 public:
     struct CacheEntry {
         QString repo_id;
@@ -55,7 +55,6 @@ public:
         QString account_sig;
     };
 
-    void start();
 
     QString getCachedFileId(const QString& repo_id,
                             const QString& path);
@@ -69,12 +68,10 @@ public:
     QList<CacheEntry> getAllCachedFiles();
 
 private:
-    FileCacheDB();
-    ~FileCacheDB();
-    static bool getCacheEntryCB(sqlite3_stmt *stmt, void *data);
-    static bool collectCachedFile(sqlite3_stmt *stmt, void *data);
+    FileCache();
+    ~FileCache();
 
-    sqlite3 *db_;
+    QCache<QString, CacheEntry> *cache_;
 };
 
 

--- a/src/filebrowser/data-cache.h
+++ b/src/filebrowser/data-cache.h
@@ -66,12 +66,13 @@ public:
                           const QString& account_sig);
 
     QList<CacheEntry> getAllCachedFiles();
+    void cleanCurrentAccountCache();
 
 private:
     FileCache();
     ~FileCache();
 
-    QCache<QString, CacheEntry> *cache_;
+    QHash<QString, CacheEntry> *cache_;
 };
 
 

--- a/src/filebrowser/data-mgr.cpp
+++ b/src/filebrowser/data-mgr.cpp
@@ -33,7 +33,7 @@ const int kPasswordCacheExpirationMSecs = 30 * 60 * 1000;
 
 DataManager::DataManager(const Account &account)
     : account_(account),
-      filecache_db_(FileCacheDB::instance()),
+      filecache_(FileCache::instance()),
       dirents_cache_(DirentsCache::instance())
 {
 }
@@ -275,7 +275,7 @@ QString DataManager::getLocalCachedFile(const QString& repo_id,
         return "";
     }
 
-    QString cached_file_id = filecache_db_->getCachedFileId(repo_id, fpath);
+    QString cached_file_id = filecache_->getCachedFileId(repo_id, fpath);
     return cached_file_id == file_id ? local_file_path : "";
 }
 
@@ -307,10 +307,10 @@ void DataManager::onFileDownloadFinished(bool success)
     if (task == NULL)
         return;
     if (success) {
-        filecache_db_->saveCachedFileId(task->repoId(),
-                                        task->path(),
-                                        task->fileId(),
-                                        account_.getSignature());
+        filecache_->saveCachedFileId(task->repoId(),
+                                     task->path(),
+                                     task->fileId(),
+                                     account_.getSignature());
         // TODO we don't want to watch readonly files
         AutoUpdateManager::instance()->watchCachedFile(
             account_, task->repoId(), task->path());

--- a/src/filebrowser/data-mgr.h
+++ b/src/filebrowser/data-mgr.h
@@ -19,7 +19,7 @@ class GetDirentsRequest;
 class GetRepoRequest;
 class CreateSubrepoRequest;
 class DirentsCache;
-class FileCacheDB;
+class FileCache;
 class FileUploadTask;
 class FileDownloadTask;
 
@@ -170,7 +170,7 @@ private:
 
     QList<SeafileApiRequest*> reqs_;
 
-    FileCacheDB *filecache_db_;
+    FileCache *filecache_;
 
     DirentsCache *dirents_cache_;
 

--- a/src/filebrowser/transfer-mgr.cpp
+++ b/src/filebrowser/transfer-mgr.cpp
@@ -114,6 +114,14 @@ void TransferManager::cancelDownload(const QString& repo_id,
     }
 }
 
+void TransferManager::cancelAllDownloadTasks()
+{
+    if (current_download_) {
+        current_download_->cancel();
+        current_download_.clear();
+    }
+    pending_downloads_.clear();
+}
 
 QList<FileDownloadTask*>
 TransferManager::getDownloadTasks(const QString& repo_id,

--- a/src/filebrowser/transfer-mgr.h
+++ b/src/filebrowser/transfer-mgr.h
@@ -47,6 +47,7 @@ public:
                                       const QString& path);
 
     void cancelDownload(const QString& repo_id, const QString& path);
+    void cancelAllDownloadTasks();
 
     /**
      * Return all download tasks for files in the `parent_dir`

--- a/src/repo-service.h
+++ b/src/repo-service.h
@@ -111,5 +111,15 @@ private:
     const QStringList cached_files_;
 };
 
+class CachedFilesCleaner : public QObject, public QRunnable {
+    Q_OBJECT
+public:
+    CachedFilesCleaner();
+    void run();
+
+private:
+    QString file_cache_dir_;
+    QString file_cache_tmp_dir_;
+};
 
 #endif // SEAFILE_CLIENT_REPO_SERVICE_H_

--- a/src/repo-service.h
+++ b/src/repo-service.h
@@ -111,15 +111,4 @@ private:
     const QStringList cached_files_;
 };
 
-class CachedFilesCleaner : public QObject, public QRunnable {
-    Q_OBJECT
-public:
-    CachedFilesCleaner();
-    void run();
-
-private:
-    QString file_cache_dir_;
-    QString file_cache_tmp_dir_;
-};
-
 #endif // SEAFILE_CLIENT_REPO_SERVICE_H_

--- a/src/seafile-applet.cpp
+++ b/src/seafile-applet.cpp
@@ -290,7 +290,6 @@ void SeafileApplet::onDaemonStarted()
     // start network-related services
     //
     NetworkStatusDetector::instance()->start();
-    FileCacheDB::instance()->start();
     AutoUpdateManager::instance()->start();
 
     AvatarService::instance()->start();

--- a/src/ui/account-view.cpp
+++ b/src/ui/account-view.cpp
@@ -29,7 +29,7 @@
 #include "filebrowser/file-browser-manager.h"
 #include "api/api-error.h"
 #include "api/requests.h"
-#include "repo-service.h"
+#include "filebrowser/auto-update-mgr.h"
 
 #include "account-view.h"
 namespace {
@@ -387,6 +387,9 @@ void AccountView::toggleAccount()
         return;
     }
 
+    CachedFilesCleaner *cleaner = new CachedFilesCleaner();
+    QThreadPool::globalInstance()->start(cleaner);
+
     // logout Account
     FileBrowserManager::getInstance()->closeAllDialogByAccount(account);
     LogoutDeviceRequest *req = new LogoutDeviceRequest(account);
@@ -432,9 +435,6 @@ void AccountView::onLogoutDeviceRequestSuccess()
         return;
     }
     seafApplet->accountManager()->clearAccountToken(account);
-
-    CachedFilesCleaner *cleaner = new CachedFilesCleaner();
-    QThreadPool::globalInstance()->start(cleaner);
 
     req->deleteLater();
 }

--- a/src/ui/account-view.cpp
+++ b/src/ui/account-view.cpp
@@ -387,8 +387,7 @@ void AccountView::toggleAccount()
         return;
     }
 
-    CachedFilesCleaner *cleaner = new CachedFilesCleaner();
-    QThreadPool::globalInstance()->start(cleaner);
+    AutoUpdateManager::instance()->cleanCachedFile();
 
     // logout Account
     FileBrowserManager::getInstance()->closeAllDialogByAccount(account);

--- a/src/ui/account-view.cpp
+++ b/src/ui/account-view.cpp
@@ -8,6 +8,7 @@
 #include <QMouseEvent>
 #include <QUrl>
 #include <QUrlQuery>
+#include <QThreadPool>
 
 #include "account.h"
 #include "seafile-applet.h"
@@ -28,6 +29,7 @@
 #include "filebrowser/file-browser-manager.h"
 #include "api/api-error.h"
 #include "api/requests.h"
+#include "repo-service.h"
 
 #include "account-view.h"
 namespace {
@@ -430,6 +432,10 @@ void AccountView::onLogoutDeviceRequestSuccess()
         return;
     }
     seafApplet->accountManager()->clearAccountToken(account);
+
+    CachedFilesCleaner *cleaner = new CachedFilesCleaner();
+    QThreadPool::globalInstance()->start(cleaner);
+
     req->deleteLater();
 }
 


### PR DESCRIPTION
每次启动客户端时，在一个线程中把 .seafile-data/file-cache 目录先重命名为 file-cache-tmp，然后删掉 file-cache-tmp。