### PR TITLE
Improved file name sort in cloud file browser.

### DIFF
--- a/src/filebrowser/file-table.cpp
+++ b/src/filebrowser/file-table.cpp
@@ -54,51 +54,6 @@ enum {
 const int DirentLockStatusRole = Qt::UserRole + 1;
 const int DirentLockOwnerRoler = Qt::UserRole + 2;
 
-int digitalCompare(const QString &left, const QString &right)
-{
-    int ret = 0;
-    if (left.compare(right) == 0)
-        return ret;
-
-    QString left_sub = left;
-    QString right_sub = right;
-    const uint min_size = left.size() < right.size()
-                          ? left.size() : right.size();
-    uint i;
-    for (i = 0; i != min_size; i++) {
-        if (left[i].isDigit() && right[i].isDigit())
-            break;
-        if (left[i] != right[i]) {
-            if (i == 0)
-                return left.compare(right);
-            break;
-        }
-    }
-    if (i == min_size) {
-        return left.compare(right);
-    }
-    left_sub = left_sub.right(left_sub.size() - i);
-    right_sub = right_sub.right(right_sub.size() - i);
-
-    const QRegExp left_digit_pattern("(\\d+)*");
-    const QRegExp right_digit_pattern("(\\d+)*");
-    const int left_pos = left_digit_pattern.indexIn(left_sub);
-    const int right_pos = right_digit_pattern.indexIn(right_sub);
-    if (left_pos != -1 && right_pos != -1) {
-        quint64 left_digit = left_digit_pattern.cap(1).toUInt();
-        quint64 right_digit = right_digit_pattern.cap(1).toUInt();
-        if (left_digit == right_digit) {
-            left_sub = left_sub.right(left_sub.size() -
-                                      left_pos - left_digit_pattern.cap(1).size());
-            right_sub = right_sub.right(right_sub.size() -
-                                        right_pos - right_digit_pattern.cap(1).size());
-            return digitalCompare(left_sub, right_sub);
-        }
-        return left_digit - right_digit;
-    }
-    return left.compare(right);
-}
-
 } // namespace
 
 FileTableViewDelegate::FileTableViewDelegate(QObject *parent)

--- a/src/filebrowser/file-table.cpp
+++ b/src/filebrowser/file-table.cpp
@@ -54,6 +54,51 @@ enum {
 const int DirentLockStatusRole = Qt::UserRole + 1;
 const int DirentLockOwnerRoler = Qt::UserRole + 2;
 
+int digitalCompare(const QString &left, const QString &right)
+{
+    int ret = 0;
+    if (left.compare(right) == 0)
+        return ret;
+
+    QString left_sub = left;
+    QString right_sub = right;
+    const uint min_size = left.size() < right.size()
+                          ? left.size() : right.size();
+    uint i;
+    for (i = 0; i != min_size; i++) {
+        if (left[i].isDigit() && right[i].isDigit())
+            break;
+        if (left[i] != right[i]) {
+            if (i == 0)
+                return left.compare(right);
+            break;
+        }
+    }
+    if (i == min_size) {
+        return left.compare(right);
+    }
+    left_sub = left_sub.right(left_sub.size() - i);
+    right_sub = right_sub.right(right_sub.size() - i);
+
+    const QRegExp left_digit_pattern("(\\d+)*");
+    const QRegExp right_digit_pattern("(\\d+)*");
+    const int left_pos = left_digit_pattern.indexIn(left_sub);
+    const int right_pos = right_digit_pattern.indexIn(right_sub);
+    if (left_pos != -1 && right_pos != -1) {
+        quint64 left_digit = left_digit_pattern.cap(1).toUInt();
+        quint64 right_digit = right_digit_pattern.cap(1).toUInt();
+        if (left_digit == right_digit) {
+            left_sub = left_sub.right(left_sub.size() -
+                                      left_pos - left_digit_pattern.cap(1).size());
+            right_sub = right_sub.right(right_sub.size() -
+                                        right_pos - right_digit_pattern.cap(1).size());
+            return digitalCompare(left_sub, right_sub);
+        }
+        return left_digit - right_digit;
+    }
+    return left.compare(right);
+}
+
 } // namespace
 
 FileTableViewDelegate::FileTableViewDelegate(QObject *parent)
@@ -1092,4 +1137,20 @@ void FileTableModel::updateThumbnail(const QPixmap& thumbnail, const QString& pa
             emit dataChanged(index(pos, 0), index(pos, FILE_COLUMN_NAME));
             break;
         }
+}
+
+bool FileTableSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
+{
+    bool is_dir_left = source_model_->direntAt(left.row())->isDir();
+    bool is_dir_right = source_model_->direntAt(right.row())->isDir();
+    if (is_dir_left != is_dir_right)
+        return sortOrder() != Qt::AscendingOrder ? is_dir_right
+                                                 : !is_dir_right;
+    else {
+        const QString left_name = source_model_->direntAt(left.row())->name;
+        const QString right_name = source_model_->direntAt(right.row())->name;
+        return digitalCompare(left_name, right_name) < 0 ? true : false;
+    }
+
+    return QSortFilterProxyModel::lessThan(left, right);
 }

--- a/src/filebrowser/file-table.h
+++ b/src/filebrowser/file-table.h
@@ -11,7 +11,6 @@
 
 #include "api/server-repo.h"
 #include "seaf-dirent.h"
-#include "seafile-applet.h"
 
 #include "thumbnail-service.h"
 
@@ -171,32 +170,8 @@ public:
         : QSortFilterProxyModel(parent), source_model_(parent) {
         setSortCaseSensitivity(Qt::CaseInsensitive);
     }
-    bool lessThan(const QModelIndex &left, const QModelIndex &right) const {
-        bool is_dir_left = source_model_->direntAt(left.row())->isDir();
-        bool is_dir_right = source_model_->direntAt(right.row())->isDir();
-        if (is_dir_left != is_dir_right)
-            return sortOrder() != Qt::AscendingOrder ? is_dir_right
-                                                     : !is_dir_right;
-        else {
-            const QString left_name = source_model_->direntAt(left.row())->name;
-            const QString right_name = source_model_->direntAt(right.row())->name;
-            const QRegExp left_digit_pattern("(\\d+)*");
-            const QRegExp right_digit_pattern("(\\d+)*");
-            int left_pos = left_digit_pattern.indexIn(left_name);
-            int right_pos = right_digit_pattern.indexIn(right_name);
-            if (left_pos != -1 && right_pos != -1) {
-                quint64 left_digit = left_digit_pattern.cap(1).toUInt();
-                quint64 right_digit = right_digit_pattern.cap(1).toUInt();
-                return left_digit < right_digit ? true : false;
-            }
-            else {
-                return QSortFilterProxyModel::lessThan(left, right);
-            }
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
 
-        }
-
-        return QSortFilterProxyModel::lessThan(left, right);
-    }
 private:
     FileTableModel* source_model_;
 };

--- a/src/filebrowser/file-table.h
+++ b/src/filebrowser/file-table.h
@@ -11,6 +11,7 @@
 
 #include "api/server-repo.h"
 #include "seaf-dirent.h"
+#include "seafile-applet.h"
 
 #include "thumbnail-service.h"
 
@@ -176,6 +177,23 @@ public:
         if (is_dir_left != is_dir_right)
             return sortOrder() != Qt::AscendingOrder ? is_dir_right
                                                      : !is_dir_right;
+        else {
+            const QString left_name = source_model_->direntAt(left.row())->name;
+            const QString right_name = source_model_->direntAt(right.row())->name;
+            const QRegExp left_digit_pattern("(\\d+)*");
+            const QRegExp right_digit_pattern("(\\d+)*");
+            int left_pos = left_digit_pattern.indexIn(left_name);
+            int right_pos = right_digit_pattern.indexIn(right_name);
+            if (left_pos != -1 && right_pos != -1) {
+                quint64 left_digit = left_digit_pattern.cap(1).toUInt();
+                quint64 right_digit = right_digit_pattern.cap(1).toUInt();
+                return left_digit < right_digit ? true : false;
+            }
+            else {
+                return QSortFilterProxyModel::lessThan(left, right);
+            }
+
+        }
 
         return QSortFilterProxyModel::lessThan(left, right);
     }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -797,3 +797,42 @@ QByteArray buildFormData(const QHash<QString, QString>& params)
     return u.encodedQuery();
 #endif
 }
+
+int digitalCompare(const QString &left, const QString &right)
+{
+    int ret = 0;
+    if (left.compare(right) == 0)
+        return ret;
+
+    QString left_sub = left;
+    QString right_sub = right;
+    const uint min_size = left.size() < right.size()
+                          ? left.size() : right.size();
+    uint i;
+    for (i = 0; i != min_size; i++) {
+        if (left[i].isDigit() && right[i].isDigit())
+            break;
+        if (left[i] != right[i])
+            return left.compare(right);
+    }
+    left_sub = left_sub.right(left_sub.size() - i);
+    right_sub = right_sub.right(right_sub.size() - i);
+
+    const QRegExp left_digit_pattern("(\\d+)*");
+    const QRegExp right_digit_pattern("(\\d+)*");
+    const int left_pos = left_digit_pattern.indexIn(left_sub);
+    const int right_pos = right_digit_pattern.indexIn(right_sub);
+    if (left_pos == 0 && right_pos == 0) {
+        quint64 left_digit = left_digit_pattern.cap(1).toUInt();
+        quint64 right_digit = right_digit_pattern.cap(1).toUInt();
+        if (left_digit == right_digit) {
+            left_sub = left_sub.right(left_sub.size() -
+                                      left_digit_pattern.cap(1).size());
+            right_sub = right_sub.right(right_sub.size() -
+                                        right_digit_pattern.cap(1).size());
+            return digitalCompare(left_sub, right_sub);
+        }
+        return left_digit - right_digit;
+    }
+    return left.compare(right);
+}

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -90,4 +90,7 @@ QUrl includeQueryParams(const QUrl& url,
                         const QHash<QString, QString>& params);
 
 QByteArray buildFormData(const QHash<QString, QString>& params);
+
+int digitalCompare(const QString &left, const QString &right);
+
 #endif

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -42,4 +42,17 @@ void Utils::testIncludeUrlParams() {
     }
 }
 
+void Utils::testDigitalCompare() {
+    QCOMPARE(::digitalCompare("9", "9"), 0);
+    QCOMPARE(::digitalCompare("aa9aa", "aa9aa"), 0);
+    QCOMPARE(::digitalCompare("99a99", "99a99"), 0);
+    QCOMPARE(::digitalCompare("9", "11"), -2);
+    QCOMPARE(::digitalCompare("1.9", "1.11"), -2);
+    QCOMPARE(::digitalCompare("1.1.1.1.9", "1.1.1.1.11"), -2);
+    QCOMPARE(::digitalCompare("a9", "a11"), -2);
+    QCOMPARE(::digitalCompare("a9aaa", "a11aaa"), -2);
+    QCOMPARE(::digitalCompare("zzz9", "bbb11"), QString::compare("zzz9", "bbb11"));
+    QCOMPARE(::digitalCompare("pp9p", "pa11a"), QString::compare("pp9p", "pa11a"));
+}
+
 QTEST_APPLESS_MAIN(Utils)

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -10,6 +10,7 @@ public:
 private slots:
     void testReadableFileSize();
     void testIncludeUrlParams();
+    void testDigitalCompare();
 };
 
 #endif // TESTS_UTILS_H


### PR DESCRIPTION
如果文件名以数字开头，排序时按照数字大小排序。
例如：1，2，3，4，5，6，7，8，9，10，11，12，13，......
而不是：1，11，12，13，14，......，2，21，22，23，24，......
![file-name-sort](https://cloud.githubusercontent.com/assets/8081131/25427802/4094f12a-2aa6-11e7-9e23-45a6395bab94.png)
