### PR TITLE
Show warning dialog when upload file to readonly shared repo.

### DIFF
--- a/src/ui/repo-tree-view.cpp
+++ b/src/ui/repo-tree-view.cpp
@@ -805,6 +805,11 @@ void RepoTreeView::dropEvent(QDropEvent *event)
 
     RepoItem *item = static_cast<RepoItem*>(standard_item);
     const ServerRepo &repo = item->repo();
+    if (repo.readonly) {
+        seafApplet->warningBox(tr("You do not have permission to upload to this folder."));
+        return;
+    }
+
     const QUrl url = event->mimeData()->urls().at(0);
 
     QString local_path = url.toLocalFile();


### PR DESCRIPTION
向只读共享的资料库拖拽上传时，通过 warningBox 提示用户“没有上传权限”。