### PR TITLE
Fix Qt Version Detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,11 +158,8 @@ SET(QT_VERSION_MAJOR 5)
 # have to keep using QtWebKit on windows because QtWebEngine can't be
 # compiled in msys2/mingw (QtWebEnigne is based on chrome, which has to be
 # compiled with MSVC.)
-FIND_PROGRAM(qmake_executable NAMES qmake qmake.exe)
-EXECUTE_PROCESS(COMMAND
-    bash -c "${qmake_executable} --version | grep -iE '^using qt version [0-9.]+' | awk '{print $4}'"
-    OUTPUT_VARIABLE DETECTED_QT_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+FIND_PACKAGE(Qt5Core)
+SET(DETECTED_QT_VERSION ${Qt5Core_VERSION})
 MESSAGE("qt5 version: ${DETECTED_QT_VERSION}")
 IF(WIN32 OR DETECTED_QT_VERSION VERSION_LESS 5.6.0)
     ADD_DEFINITIONS(-DSEAFILE_USE_WEBKIT)


### PR DESCRIPTION
Explicitly calling qmake to determine the Qt version is not really
necessary and probably bad style.
Still needs to be tested on Windows and Mac OS though.