### PR TITLE
Improved "load more button" in activities and search tab.

### DIFF
--- a/src/api/requests.cpp
+++ b/src/api/requests.cpp
@@ -817,7 +817,7 @@ void FileSearchRequest::requestSuccess(QNetworkReply& reply)
     json_error_t error;
     json_t* root = parseJSON(reply, &error);
     if (!root) {
-        qWarning("FileSearchResult: failed to parse jsn:%s\n", error.text);
+        qWarning("FileSearchResult: failed to parse json:%s\n", error.text);
         emit failed(ApiError::fromJsonError());
         return;
     }
@@ -844,7 +844,13 @@ void FileSearchRequest::requestSuccess(QNetworkReply& reply)
         tmp.size = map["size"].toLongLong();
         retval.push_back(tmp);
     }
-    emit success(retval);
+
+    bool has_more = false;
+    if (dict.contains("has_more")) {
+        has_more = json_is_true(json_object_get(json.data(), "has_more"));
+    }
+
+    emit success(retval, has_more);
 }
 
 FetchCustomLogoRequest::FetchCustomLogoRequest(const QUrl& url)

--- a/src/api/requests.h
+++ b/src/api/requests.h
@@ -527,7 +527,8 @@ public:
     }
 
 signals:
-    void success(const std::vector<FileSearchResult>& result);
+    void success(const std::vector<FileSearchResult>& result,
+                 bool has_more);
 
 protected slots:
     void requestSuccess(QNetworkReply& reply);

--- a/src/events-service.cpp
+++ b/src/events-service.cpp
@@ -81,19 +81,13 @@ void EventsService::onRefreshSuccess(const std::vector<SeafEvent>& events, int n
 {
     in_refresh_ = false;
 
-    // XXX: uncomment this when we need "load more events feature"
-    /*
     const std::vector<SeafEvent> new_events = handleEventsOffset(events);
 
     bool is_loading_more = more_offset_ > 0;
     bool has_more = new_offset > 0;
-
     more_offset_ = new_offset;
 
     emit refreshSuccess(new_events, is_loading_more, has_more);
-    */
-
-    emit refreshSuccess(events, false, false);
 }
 
 // We use the "offset" param as the starting point of loading more events, but

--- a/src/ui/activities-tab.cpp
+++ b/src/ui/activities-tab.cpp
@@ -77,7 +77,7 @@ void ActivitiesTab::loadMoreEvents()
 {
     events_loading_view_ = new LoadingView;
     events_list_view_->setIndexWidget(
-        events_list_model_->load_more_index, events_loading_view_);
+        events_list_model_->loadMoreIndex(), events_loading_view_);
     EventsService::instance()->loadMore();
 }
 
@@ -86,7 +86,7 @@ void ActivitiesTab::refreshEvents(const std::vector<SeafEvent>& events,
                                   bool has_more)
 {
     events_list_model_->removeRow(
-        events_list_model_->load_more_index.row());
+        events_list_model_->loadMoreIndex().row());
 
     mStack->setCurrentIndex(INDEX_EVENTS_VIEW);
 
@@ -102,7 +102,7 @@ void ActivitiesTab::refreshEvents(const std::vector<SeafEvent>& events,
         connect(load_more_btn_, SIGNAL(clicked()),
                 this, SLOT(loadMoreEvents()));
         events_list_view_->setIndexWidget(
-            events_list_model_->load_more_index, load_more_btn_);
+            events_list_model_->loadMoreIndex(), load_more_btn_);
     }
 }
 

--- a/src/ui/activities-tab.h
+++ b/src/ui/activities-tab.h
@@ -10,7 +10,7 @@ class QSslError;
 class QUrl;
 class QNetworkRequest;
 class QNetworkReply;
-class QToolButton;
+class LoadMoreButton;
 class QLabel;
 class QShowEvent;
 
@@ -58,7 +58,7 @@ private:
     EventsListView *events_list_view_;
     EventsListModel *events_list_model_;
     QWidget *events_loading_view_;
-    QToolButton *load_more_btn_;
+    LoadMoreButton *load_more_btn_;
 
     QLabel *loading_failed_text_;
 };

--- a/src/ui/events-list-view.cpp
+++ b/src/ui/events-list-view.cpp
@@ -93,7 +93,12 @@ void EventItemDelegate::paint(QPainter *painter,
 {
     QBrush backBrush;
     bool selected = false;
+
     EventItem *item = getItem(index);
+    if (!item) {
+        return;
+    }
+
     const SeafEvent& event = item->event();
     QString time_text = translateCommitTime(event.timestamp);
 
@@ -265,8 +270,9 @@ EventItemDelegate::getItem(const QModelIndex &index) const
     QStandardItem *qitem = model->itemFromIndex(index);
     if (qitem->type() == EVENT_ITEM_TYPE) {
         return (EventItem *)qitem;
+    } else {
+        return NULL;
     }
-    return NULL;
 }
 
 EventsListView::EventsListView(QWidget *parent)
@@ -349,7 +355,9 @@ EventsListModel::EventsListModel(QObject *parent)
 }
 
 const QModelIndex
-EventsListModel::updateEvents(const std::vector<SeafEvent>& events, bool is_loading_more)
+EventsListModel::updateEvents(const std::vector<SeafEvent>& events,
+                              bool is_loading_more,
+                              bool has_more)
 {
     if (!is_loading_more) {
         clear();
@@ -367,6 +375,12 @@ EventsListModel::updateEvents(const std::vector<SeafEvent>& events, bool is_load
         if (!first_item) {
             first_item = item;
         }
+    }
+
+    if (has_more) {
+        QStandardItem *load_more_item = new QStandardItem();
+        appendRow(load_more_item);
+        load_more_index = load_more_item->index();
     }
 
     if (is_loading_more && first_item) {

--- a/src/ui/events-list-view.cpp
+++ b/src/ui/events-list-view.cpp
@@ -380,7 +380,7 @@ EventsListModel::updateEvents(const std::vector<SeafEvent>& events,
     if (has_more) {
         QStandardItem *load_more_item = new QStandardItem();
         appendRow(load_more_item);
-        load_more_index = load_more_item->index();
+        load_more_index_ = load_more_item->index();
     }
 
     if (is_loading_more && first_item) {

--- a/src/ui/events-list-view.h
+++ b/src/ui/events-list-view.h
@@ -62,9 +62,13 @@ public:
     const QModelIndex updateEvents(const std::vector<SeafEvent>& events,
                                    bool is_loading_more,
                                    bool has_more);
-    QModelIndex load_more_index;
+    const QModelIndex loadMoreIndex() const { return load_more_index_; }
+
 public slots:
     void onAvatarUpdated(const QString& email, const QImage& img);
+
+private:
+    QModelIndex load_more_index_;
 };
 
 class EventsListView : public QListView {

--- a/src/ui/events-list-view.h
+++ b/src/ui/events-list-view.h
@@ -59,8 +59,10 @@ class EventsListModel : public QStandardItemModel {
 public:
     EventsListModel(QObject *parent=0);
 
-    const QModelIndex updateEvents(const std::vector<SeafEvent>& events, bool is_loading_more);
-
+    const QModelIndex updateEvents(const std::vector<SeafEvent>& events,
+                                   bool is_loading_more,
+                                   bool has_more);
+    QModelIndex load_more_index;
 public slots:
     void onAvatarUpdated(const QString& email, const QImage& img);
 };

--- a/src/ui/loading-view.cpp
+++ b/src/ui/loading-view.cpp
@@ -47,3 +47,26 @@ void LoadingView::setQssStyleForTab()
     setStyleSheet(kLoadingViewQss);
 }
 
+LoadMoreButton::LoadMoreButton(QWidget *parent)
+    : QToolButton(parent)
+{
+    setText(tr("load more"));
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    setAutoFillBackground(true);
+}
+
+void LoadMoreButton::paintEvent(QPaintEvent *event)
+{
+    QPainter painter(this);
+    const char *kLoadMoreBackgroundColor = "white";
+    QBrush backBrush = QColor(kLoadMoreBackgroundColor);
+    painter.fillRect(event->rect(), backBrush);
+    const char *kLoadMoreColor = "#D8AC8F";
+    painter.setPen(QColor(kLoadMoreColor));
+    const int kLoadMoreFontSize = 16;
+    QFont font;
+    font.setUnderline(true);
+    font.setPixelSize(kLoadMoreFontSize);
+    painter.setFont(font);
+    painter.drawText(event->rect(), Qt::AlignCenter, text());
+}

--- a/src/ui/loading-view.h
+++ b/src/ui/loading-view.h
@@ -2,6 +2,7 @@
 #define SEAFILE_CLIENT_LOADING_VIEW_H_
 
 #include <QWidget>
+#include <QToolButton>
 
 class QMovie;
 class QShowEvent;
@@ -21,6 +22,14 @@ private:
     Q_DISABLE_COPY(LoadingView)
 
     QMovie *gif_;
+};
+
+class LoadMoreButton : public QToolButton {
+    Q_OBJECT
+public:
+    explicit LoadMoreButton(QWidget *parent=0);
+private:
+    void paintEvent(QPaintEvent *event);
 };
 
 #endif // SEAFILE_CLIENT_LOADING_VIEW_H_

--- a/src/ui/search-tab-items.h
+++ b/src/ui/search-tab-items.h
@@ -48,7 +48,7 @@ public:
     }
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const
     {
-        if (index.row() >= (int)items_.size())
+        if (!index.isValid() || index.row() >= (int)items_.size())
             return QVariant();
         return items_[index.row()]->data(role);
     }

--- a/src/ui/search-tab.cpp
+++ b/src/ui/search-tab.cpp
@@ -224,8 +224,8 @@ void SearchTab::doRealSearch()
     }
     mStack->setCurrentIndex(INDEX_LOADING_VIEW);
     request_ = new FileSearchRequest(seafApplet->accountManager()->accounts().front(), line_edit_->text());
-    connect(request_, SIGNAL(success(const std::vector<FileSearchResult>&)),
-            this, SLOT(onSearchSuccess(const std::vector<FileSearchResult>&)));
+    connect(request_, SIGNAL(success(const std::vector<FileSearchResult>&, bool)),
+            this, SLOT(onSearchSuccess(const std::vector<FileSearchResult>&, bool)));
     connect(request_, SIGNAL(failed(const ApiError&)),
             this, SLOT(onSearchFailed(const ApiError&)));
 
@@ -235,7 +235,8 @@ void SearchTab::doRealSearch()
     last_modified_ = 0;
 }
 
-void SearchTab::onSearchSuccess(const std::vector<FileSearchResult>& results)
+void SearchTab::onSearchSuccess(const std::vector<FileSearchResult>& results,
+                                bool has_more)
 {
     std::vector<QListWidgetItem*> items;
 
@@ -253,6 +254,10 @@ void SearchTab::onSearchSuccess(const std::vector<FileSearchResult>& results)
     search_model_->addItems(items);
 
     mStack->setCurrentIndex(INDEX_SEARCH_VIEW);
+
+    if (has_more) {
+
+    }
 }
 
 void SearchTab::onSearchFailed(const ApiError& error)

--- a/src/ui/search-tab.h
+++ b/src/ui/search-tab.h
@@ -37,7 +37,8 @@ private slots:
 
     void onDoubleClicked(const QModelIndex& index);
 
-    void onSearchSuccess(const std::vector<FileSearchResult>& results);
+    void onSearchSuccess(const std::vector<FileSearchResult>& results,
+                         bool has_more);
     void onSearchFailed(const ApiError& error);
 
 private:


### PR DESCRIPTION
新建 class LoadMoreButton 并通过 LoadMoreButton::paintEvent() 自定义 LoadMoreButton 的图样。
使用 QAbstractItemView::setIndexWidget() 将 LoadMoreButton 或 LoadingView 嵌入到当前 EventsList 的最后一行，并实现 LoadMoreButton 与 LoadingView 之间的切换。
刷新成功后，通过 QAbstractItemModel::removeRow() 将 LoadingView 所在行删除。

改进前效果：
![2017-06-10 09-46-27](https://user-images.githubusercontent.com/8081131/27033820-9a8c836a-4fad-11e7-81a1-6a4c1ef11521.png)
![2017-06-10 09-47-16](https://user-images.githubusercontent.com/8081131/27033831-a595c4d8-4fad-11e7-9f15-0c912773e974.png)

改进后效果：
![2017-06-12 20-09-05](https://user-images.githubusercontent.com/8081131/27033846-b318fc1a-4fad-11e7-9dae-667985818cc9.png)
![2017-06-12 20-10-07](https://user-images.githubusercontent.com/8081131/27033854-c0e26a98-4fad-11e7-9349-159cd9e6dcda.png)

