### PR TITLE
Added empty folder view in cloud file browser.

### DIFF
--- a/src/filebrowser/file-browser-dialog.cpp
+++ b/src/filebrowser/file-browser-dialog.cpp
@@ -37,10 +37,12 @@ namespace {
 enum {
     INDEX_LOADING_VIEW = 0,
     INDEX_TABLE_VIEW,
-    INDEX_LOADING_FAILED_VIEW
+    INDEX_LOADING_FAILED_VIEW,
+    INDEX_EMPTY_VIEW
 };
 
 const char *kLoadingFaieldLabelName = "loadingFailedText";
+const char *kEmptyFolderLabelName = "emptyFolderText";
 const int kToolBarIconSize = 20;
 const int kStatusBarIconSize = 24;
 //const int kStatusCodePasswordNeeded = 400;
@@ -106,6 +108,7 @@ FileBrowserDialog::FileBrowserDialog(const Account &account, const ServerRepo& r
     createToolBar();
     createStatusBar();
     createLoadingFailedView();
+    createEmptyView();
     createFileTable();
 
     QWidget* widget = new QWidget;
@@ -125,6 +128,7 @@ FileBrowserDialog::FileBrowserDialog(const Account &account, const ServerRepo& r
     stack_->insertWidget(INDEX_LOADING_VIEW, loading_view_);
     stack_->insertWidget(INDEX_TABLE_VIEW, table_view_);
     stack_->insertWidget(INDEX_LOADING_FAILED_VIEW, loading_failed_view_);
+    stack_->insertWidget(INDEX_EMPTY_VIEW, empty_view_);
     stack_->setContentsMargins(0, 0, 0, 0);
 
     vlayout->addWidget(toolbar_);
@@ -423,6 +427,23 @@ void FileBrowserDialog::createLoadingFailedView()
 
     connect(label, SIGNAL(linkActivated(const QString&)),
             this, SLOT(forceRefresh()));
+
+    layout->addWidget(label);
+}
+
+void FileBrowserDialog::createEmptyView()
+{
+    empty_view_ = new QWidget(this);
+
+    QVBoxLayout *layout = new QVBoxLayout;
+    empty_view_->setLayout(layout);
+
+    QLabel *label = new QLabel;
+    label->setObjectName(kEmptyFolderLabelName);
+    label->setMargin(20);
+    QString label_text = tr("This folder is empty.");
+    label->setText(label_text);
+    label->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
 
     layout->addWidget(label);
 }
@@ -858,6 +879,11 @@ void FileBrowserDialog::goHome()
 
 void FileBrowserDialog::updateTable(const QList<SeafDirent>& dirents)
 {
+    if (dirents.isEmpty()) {
+        stack_->setCurrentIndex(INDEX_EMPTY_VIEW);
+        return;
+    }
+
     table_model_->setDirents(dirents);
     stack_->setCurrentIndex(INDEX_TABLE_VIEW);
     if (!forward_history_.empty()) {

--- a/src/filebrowser/file-browser-dialog.cpp
+++ b/src/filebrowser/file-browser-dialog.cpp
@@ -440,10 +440,9 @@ void FileBrowserDialog::createEmptyView()
 
     QLabel *label = new QLabel;
     label->setObjectName(kEmptyFolderLabelName);
-    label->setMargin(20);
     QString label_text = tr("This folder is empty.");
     label->setText(label_text);
-    label->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
+    label->setAlignment(Qt::AlignCenter);
 
     layout->addWidget(label);
 }

--- a/src/filebrowser/file-browser-dialog.cpp
+++ b/src/filebrowser/file-browser-dialog.cpp
@@ -42,7 +42,6 @@ enum {
 };
 
 const char *kLoadingFaieldLabelName = "loadingFailedText";
-const char *kEmptyFolderLabelName = "emptyFolderText";
 const int kToolBarIconSize = 20;
 const int kStatusBarIconSize = 24;
 //const int kStatusCodePasswordNeeded = 400;
@@ -433,18 +432,9 @@ void FileBrowserDialog::createLoadingFailedView()
 
 void FileBrowserDialog::createEmptyView()
 {
-    empty_view_ = new QWidget(this);
-
-    QVBoxLayout *layout = new QVBoxLayout;
-    empty_view_->setLayout(layout);
-
-    QLabel *label = new QLabel;
-    label->setObjectName(kEmptyFolderLabelName);
-    QString label_text = tr("This folder is empty.");
-    label->setText(label_text);
-    label->setAlignment(Qt::AlignCenter);
-
-    layout->addWidget(label);
+    empty_view_ = new QLabel;
+    empty_view_->setText(tr("This folder is empty."));
+    empty_view_->setAlignment(Qt::AlignCenter);
 }
 
 void FileBrowserDialog::onDirentClicked(const SeafDirent& dirent)

--- a/src/filebrowser/file-browser-dialog.h
+++ b/src/filebrowser/file-browser-dialog.h
@@ -186,7 +186,7 @@ private:
     QStackedWidget *stack_;
     QWidget *loading_view_;
     QWidget *loading_failed_view_;
-    QWidget *empty_view_;
+    QLabel *empty_view_;
     FileTableView *table_view_;
     FileTableModel *table_model_;
 

--- a/src/filebrowser/file-browser-dialog.h
+++ b/src/filebrowser/file-browser-dialog.h
@@ -126,6 +126,7 @@ private:
     void createStatusBar();
     void createFileTable();
     void createLoadingFailedView();
+    void createEmptyView();
     void showLoading();
     void updateTable(const QList<SeafDirent>& dirents);
     void createDirectory(const QString &name);
@@ -185,6 +186,7 @@ private:
     QStackedWidget *stack_;
     QWidget *loading_view_;
     QWidget *loading_failed_view_;
+    QWidget *empty_view_;
     FileTableView *table_view_;
     FileTableModel *table_model_;
 


### PR DESCRIPTION
当 cloud file browser 目录内容为空时，显示一行提示信息 “This folder is empty.”

![-add-spacer](https://user-images.githubusercontent.com/8081131/27183608-c801d05a-5211-11e7-8710-75c980844223.PNG)
