### PR TITLE
Disabled show_sync_errors menu item in tray icon when there is no sync error.

### DIFF
--- a/src/ui/sync-errors-dialog.cpp
+++ b/src/ui/sync-errors-dialog.cpp
@@ -220,8 +220,8 @@ SyncErrorsTableModel::SyncErrorsTableModel(QObject *parent)
 void SyncErrorsTableModel::updateErrors()
 {
     std::vector<SyncError> errors;
-    int ret = seafApplet->rpcClient()->getSyncErrors(&errors, 0, 50);
-    if (ret < 0) {
+    bool success = seafApplet->rpcClient()->getSyncErrors(&errors, 0, 50);
+    if (!success) {
         qDebug("failed to get sync errors");
         return;
     }

--- a/src/ui/tray-icon.cpp
+++ b/src/ui/tray-icon.cpp
@@ -232,8 +232,8 @@ void SeafileTrayIcon::prepareContextMenu()
     }
 
     std::vector<SyncError> errors;
-    int ret = seafApplet->rpcClient()->getSyncErrors(&errors, 0, 1);
-    if (ret < 0) {
+    bool success = seafApplet->rpcClient()->getSyncErrors(&errors, 0, 1);
+    if (!success) {
         qDebug("failed to get sync errors");
         return;
     }

--- a/src/ui/tray-icon.cpp
+++ b/src/ui/tray-icon.cpp
@@ -230,6 +230,19 @@ void SeafileTrayIcon::prepareContextMenu()
         enable_auto_sync_action_->setVisible(true);
         disable_auto_sync_action_->setVisible(false);
     }
+
+    std::vector<SyncError> errors;
+    int ret = seafApplet->rpcClient()->getSyncErrors(&errors, 0, 1);
+    if (ret < 0) {
+        qDebug("failed to get sync errors");
+        return;
+    }
+
+    if (errors.empty()) {
+        show_sync_errors_action_->setEnabled(false);
+    } else {
+        show_sync_errors_action_->setEnabled(true);
+    }
 }
 
 void SeafileTrayIcon::createGlobalMenuBar()


### PR DESCRIPTION
Disabled show_sync_errors menu item in tray icon when there is no sync error.