### PR TITLE
fix build with openssl 1.1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: m.eik michalke <meik.michalke@hhu.de>
 Build-Depends:
     debhelper (>= 7),
-    libssl1.0-dev | libssl-dev (<< 1.1),
+    libssl-dev,
     libcurl4-openssl-dev,
     libsqlite3-dev,
     intltool,

--- a/src/ccnet-init.cpp
+++ b/src/ccnet-init.cpp
@@ -136,8 +136,6 @@ int make_config_dir(const char *ccnet_dir)
 
 int create_ccnet_config (const char *ccnet_dir)
 {
-    SSLeay_add_all_algorithms();
-
     g_assert (RAND_status() == 1);
 
     if (bits == 0)

--- a/src/utils/rsa.cpp
+++ b/src/utils/rsa.cpp
@@ -41,18 +41,21 @@ GString* public_key_to_gstring(const RSA *rsa)
     GString *buf = g_string_new(NULL);
     unsigned char *temp;
     char *coded;
+    const BIGNUM *n, *e;
 
-    gsize len = BN_num_bytes(rsa->n);
+    RSA_get0_key(rsa, &n, &e, NULL);
+
+    gsize len = BN_num_bytes(n);
     temp = (unsigned char *)malloc(len);
-    BN_bn2bin(rsa->n, temp);
+    BN_bn2bin(n, temp);
     coded = g_base64_encode(temp, len);
     g_string_append (buf, coded);
     g_string_append_c (buf, ' ');
     g_free(coded);
 
-    len = BN_num_bytes(rsa->e);
+    len = BN_num_bytes(e);
     temp = (unsigned char*)realloc(temp, len);
-    BN_bn2bin(rsa->e, temp);
+    BN_bn2bin(e, temp);
     coded = g_base64_encode(temp, len);
     g_string_append (buf, coded);
     g_free(coded);
@@ -106,9 +109,10 @@ RSA*
 private_key_to_pub(RSA *priv)
 {
     RSA *pub = RSA_new();
+    const BIGNUM *n, *e;
 
-    pub->n = BN_dup(priv->n);
-    pub->e = BN_dup(priv->e);
+    RSA_get0_key(priv, &n, &e, NULL);
+    RSA_set0_key(pub, BN_dup(n), BN_dup(e), NULL);
 
     return pub;
 }


### PR DESCRIPTION
Fix #899 and https://bugs.debian.org/859716

Builds fine in a sid chroot.

`SSLeay_add_all_algorithms` is not required as the operation is done automatically.