### PR TITLE
Accept close event instead of ignoring it

### DIFF
--- a/src/ui/main-window.cpp
+++ b/src/ui/main-window.cpp
@@ -112,7 +112,7 @@ void MainWindow::hide()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-    event->ignore();
+    event->accept();
     hide();
 }
 


### PR DESCRIPTION
Ignoring main window close event causes weird behavior as described in the forum post: https://forum.seafile.com/t/plasma-logout-canceled-by-seafile-applet/3283

VLC used to have similar issue: https://trac.videolan.org/vlc/ticket/4606

This PR replaces ignore() call with accept() which fixes that issue. I haven't noticed any problems with exit-to-tray feature. Tested on Arch Linux.