### PR TITLE
Server index asynchronously save

### DIFF
--- a/src/filebrowser/file-browser-requests.cpp
+++ b/src/filebrowser/file-browser-requests.cpp
@@ -394,8 +394,7 @@ void GetFileUploadedBytesRequest::requestSuccess(QNetworkReply &reply)
 }
 
 GetIndexProgressRequest::GetIndexProgressRequest(const QUrl &url, const QString &task_id)
-    : SeafileApiRequest(url,
-                        SeafileApiRequest::METHOD_GET)
+    : SeafileApiRequest(url, SeafileApiRequest::METHOD_GET)
 {
     setUrlParam("task_id", task_id);
 }

--- a/src/filebrowser/file-browser-requests.cpp
+++ b/src/filebrowser/file-browser-requests.cpp
@@ -21,7 +21,6 @@ const char kFileOperationCopy[] = "api2/repos/%1/fileops/copy/";
 const char kFileOperationMove[] = "api2/repos/%1/fileops/move/";
 const char kRemoveDirentsURL[] = "api2/repos/%1/fileops/delete/";
 const char kGetFileUploadedBytesUrl[] = "api/v2.1/repos/%1/file-uploaded-bytes/";
-const char kQueryIndexUrl[] = "idx_progress";
 //const char kGetFileFromRevisionUrl[] = "api2/repos/%1/file/revision/";
 //const char kGetFileDetailUrl[] = "api2/repos/%1/file/detail/";
 //const char kGetFileHistoryUrl[] = "api2/repos/%1/file/history/";
@@ -394,19 +393,19 @@ void GetFileUploadedBytesRequest::requestSuccess(QNetworkReply &reply)
     emit success(true, uploaded_bytes);
 }
 
-QueryIndexRequest::QueryIndexRequest(const QUrl &url, const QString &task_id)
-    : SeafileApiRequest(::urlJoin(url, kQueryIndexUrl),
+GetIndexProgressRequest::GetIndexProgressRequest(const QUrl &url, const QString &task_id)
+    : SeafileApiRequest(url,
                         SeafileApiRequest::METHOD_GET)
 {
     setUrlParam("task_id", task_id);
 }
 
-void QueryIndexRequest::requestSuccess(QNetworkReply& reply)
+void GetIndexProgressRequest::requestSuccess(QNetworkReply& reply)
 {
     json_error_t error;
     json_t *root = parseJSON(reply, &error);
     if (!root) {
-        qDebug("QueryIndexRequest: failed to parse json:%s\n", error.text);
+        qDebug("GetIndexProgressRequest: failed to parse json:%s\n", error.text);
         emit failed(ApiError::fromJsonError());
         return;
     }
@@ -414,7 +413,7 @@ void QueryIndexRequest::requestSuccess(QNetworkReply& reply)
     QScopedPointer<json_t, JsonPointerCustomDeleter> json(root);
 
     QMap<QString, QVariant> dict = mapFromJSON(json.data(), &error);
-    QueryIndexResult result;
+    GetIndexProgressResult result;
 
     result.total = dict.value("total").toInt();
     result.indexed = dict.value("indexed").toInt();

--- a/src/filebrowser/file-browser-requests.cpp
+++ b/src/filebrowser/file-browser-requests.cpp
@@ -404,7 +404,7 @@ void GetIndexProgressRequest::requestSuccess(QNetworkReply& reply)
     json_error_t error;
     json_t *root = parseJSON(reply, &error);
     if (!root) {
-        qDebug("GetIndexProgressRequest: failed to parse json:%s\n", error.text);
+        qWarning("GetIndexProgressRequest: failed to parse json:%s\n", error.text);
         emit failed(ApiError::fromJsonError());
         return;
     }
@@ -412,7 +412,7 @@ void GetIndexProgressRequest::requestSuccess(QNetworkReply& reply)
     QScopedPointer<json_t, JsonPointerCustomDeleter> json(root);
 
     QMap<QString, QVariant> dict = mapFromJSON(json.data(), &error);
-    GetIndexProgressResult result;
+    ServerIndexProgress result;
 
     result.total = dict.value("total").toInt();
     result.indexed = dict.value("indexed").toInt();

--- a/src/filebrowser/file-browser-requests.cpp
+++ b/src/filebrowser/file-browser-requests.cpp
@@ -21,6 +21,7 @@ const char kFileOperationCopy[] = "api2/repos/%1/fileops/copy/";
 const char kFileOperationMove[] = "api2/repos/%1/fileops/move/";
 const char kRemoveDirentsURL[] = "api2/repos/%1/fileops/delete/";
 const char kGetFileUploadedBytesUrl[] = "api/v2.1/repos/%1/file-uploaded-bytes/";
+const char kQueryIndexUrl[] = "idx_progress";
 //const char kGetFileFromRevisionUrl[] = "api2/repos/%1/file/revision/";
 //const char kGetFileDetailUrl[] = "api2/repos/%1/file/detail/";
 //const char kGetFileHistoryUrl[] = "api2/repos/%1/file/history/";
@@ -391,4 +392,32 @@ void GetFileUploadedBytesRequest::requestSuccess(QNetworkReply &reply)
     quint64 uploaded_bytes = dict["uploadedBytes"].toLongLong();
     // printf ("uploadedBytes = %lld\n", uploaded_bytes);
     emit success(true, uploaded_bytes);
+}
+
+QueryIndexRequest::QueryIndexRequest(const QUrl &url, const QString &task_id)
+    : SeafileApiRequest(::urlJoin(url, kQueryIndexUrl),
+                        SeafileApiRequest::METHOD_GET)
+{
+    setUrlParam("task_id", task_id);
+}
+
+void QueryIndexRequest::requestSuccess(QNetworkReply& reply)
+{
+    json_error_t error;
+    json_t *root = parseJSON(reply, &error);
+    if (!root) {
+        qDebug("QueryIndexRequest: failed to parse json:%s\n", error.text);
+        emit failed(ApiError::fromJsonError());
+        return;
+    }
+
+    QScopedPointer<json_t, JsonPointerCustomDeleter> json(root);
+
+    QMap<QString, QVariant> dict = mapFromJSON(json.data(), &error);
+    QueryIndexResult result;
+
+    result.total = dict.value("total").toInt();
+    result.indexed = dict.value("indexed").toInt();
+    result.status = dict.value("status").toInt();
+    emit success(result);
 }

--- a/src/filebrowser/file-browser-requests.h
+++ b/src/filebrowser/file-browser-requests.h
@@ -344,4 +344,24 @@ private:
     const QString file_name_;
 };
 
+struct QueryIndexResult {
+    qint64 total;
+    qint64 indexed;
+    qint64 status;
+};
+
+class QueryIndexRequest : public SeafileApiRequest {
+    Q_OBJECT
+public:
+    QueryIndexRequest(const QUrl &url, const QString &task_id);
+signals:
+    void success(const QueryIndexResult& result);
+
+protected slots:
+    void requestSuccess(QNetworkReply& reply);
+
+private:
+    Q_DISABLE_COPY(QueryIndexRequest);
+};
+
 #endif  // SEAFILE_CLIENT_FILE_BROWSER_REQUESTS_H

--- a/src/filebrowser/file-browser-requests.h
+++ b/src/filebrowser/file-browser-requests.h
@@ -344,24 +344,24 @@ private:
     const QString file_name_;
 };
 
-struct QueryIndexResult {
+struct GetIndexProgressResult {
     qint64 total;
     qint64 indexed;
     qint64 status;
 };
 
-class QueryIndexRequest : public SeafileApiRequest {
+class GetIndexProgressRequest : public SeafileApiRequest {
     Q_OBJECT
 public:
-    QueryIndexRequest(const QUrl &url, const QString &task_id);
+    GetIndexProgressRequest(const QUrl &url, const QString &task_id);
 signals:
-    void success(const QueryIndexResult& result);
+    void success(const GetIndexProgressResult& result);
 
 protected slots:
     void requestSuccess(QNetworkReply& reply);
 
 private:
-    Q_DISABLE_COPY(QueryIndexRequest);
+    Q_DISABLE_COPY(GetIndexProgressRequest);
 };
 
 #endif  // SEAFILE_CLIENT_FILE_BROWSER_REQUESTS_H

--- a/src/filebrowser/file-browser-requests.h
+++ b/src/filebrowser/file-browser-requests.h
@@ -344,7 +344,7 @@ private:
     const QString file_name_;
 };
 
-struct GetIndexProgressResult {
+struct ServerIndexProgress {
     qint64 total;
     qint64 indexed;
     qint64 status;
@@ -355,7 +355,7 @@ class GetIndexProgressRequest : public SeafileApiRequest {
 public:
     GetIndexProgressRequest(const QUrl &url, const QString &task_id);
 signals:
-    void success(const GetIndexProgressResult& result);
+    void success(const ServerIndexProgress& result);
 
 protected slots:
     void requestSuccess(QNetworkReply& reply);

--- a/src/filebrowser/progress-dialog.cpp
+++ b/src/filebrowser/progress-dialog.cpp
@@ -38,7 +38,7 @@ FileBrowserProgressDialog::FileBrowserProgressDialog(FileNetworkTask *task, QWid
     QHBoxLayout *hlayout_ = new QHBoxLayout;
     more_details_label_ = new QLabel;
     more_details_label_->setText(tr("Pending"));
-    QPushButton *cancel_button_ = new QPushButton(tr("Cancel"));
+    cancel_button_ = new QPushButton(tr("Cancel"));
     QWidget *spacer = new QWidget;
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
@@ -142,14 +142,16 @@ void FileBrowserProgressDialog::onTaskFinished(bool success)
         return;
     }
 
-    oid_ = task_->oid();
+    cancel_button_->setVisible(false);
+
+    progerss_id_ = task_->oid();
     progress_url_ = ::urlJoin(QUrl(task_->url().toString(QUrl::PrettyDecoded).
                                    section("upload", 0, 0)), kQueryIndexUrl);
     if (success) {
         // printf ("progress dialog: task success\n");
 
         //Judge "-" as a task id or a file id
-        if (oid_.contains("-")) {
+        if (progerss_id_.contains("-")) {
             onQueryUpdate();
             index_progress_timer_->start(3000);
         } else {
@@ -168,7 +170,7 @@ void FileBrowserProgressDialog::onQueryUpdate()
         progress_request_ = NULL;
     }
 
-    progress_request_ = new GetIndexProgressRequest(progress_url_, oid_);
+    progress_request_ = new GetIndexProgressRequest(progress_url_, progerss_id_);
     connect(progress_request_, SIGNAL(success(const GetIndexProgressResult&)),
             this, SLOT(onQuerySuccess(const GetIndexProgressResult&)));
 

--- a/src/filebrowser/progress-dialog.h
+++ b/src/filebrowser/progress-dialog.h
@@ -43,6 +43,7 @@ private:
     QLabel *more_details_label_;
     QProgressBar *progress_bar_;
     QUrl progress_url_;
+    QString oid_;
     GetIndexProgressRequest *progress_request_;
     QTimer *index_progress_timer_;
 };

--- a/src/filebrowser/progress-dialog.h
+++ b/src/filebrowser/progress-dialog.h
@@ -39,11 +39,12 @@ private slots:
 private:
 
     FileNetworkTask* task_;
+    QPushButton *cancel_button_;
     QLabel *description_label_;
     QLabel *more_details_label_;
     QProgressBar *progress_bar_;
     QUrl progress_url_;
-    QString oid_;
+    QString progerss_id_;
     GetIndexProgressRequest *progress_request_;
     QTimer *index_progress_timer_;
 };

--- a/src/filebrowser/progress-dialog.h
+++ b/src/filebrowser/progress-dialog.h
@@ -3,6 +3,7 @@
 
 #include <QProgressDialog>
 #include <QObject>
+#include <QTimer>
 
 #include "tasks.h"
 
@@ -32,7 +33,7 @@ private slots:
     void initTaskInfo();
     void onOneFileUploadFailed(const QString& filename, bool single_file);
     void onQueryUpdate();
-    void onQuerySuccess(const QueryIndexResult& result);
+    void onQuerySuccess(const GetIndexProgressResult& result);
     ActionOnFailure retryOrSkipOrAbort(const QString& msg, bool single_file);
 
 private:
@@ -41,10 +42,9 @@ private:
     QLabel *description_label_;
     QLabel *more_details_label_;
     QProgressBar *progress_bar_;
-    QString oid_;
-    QUrl url_;
-    QueryIndexRequest *query_request_;
-    qint64 query_status_;
+    QUrl progress_url_;
+    GetIndexProgressRequest *progress_request_;
+    QTimer *index_progress_timer_;
 };
 
 

--- a/src/filebrowser/progress-dialog.h
+++ b/src/filebrowser/progress-dialog.h
@@ -31,6 +31,8 @@ private slots:
     void onTaskFinished(bool success);
     void initTaskInfo();
     void onOneFileUploadFailed(const QString& filename, bool single_file);
+    void onQueryUpdate();
+    void onQuerySuccess(const QueryIndexResult& result);
     ActionOnFailure retryOrSkipOrAbort(const QString& msg, bool single_file);
 
 private:
@@ -39,6 +41,10 @@ private:
     QLabel *description_label_;
     QLabel *more_details_label_;
     QProgressBar *progress_bar_;
+    QString oid_;
+    QUrl url_;
+    QueryIndexRequest *query_request_;
+    qint64 query_status_;
 };
 
 

--- a/src/filebrowser/progress-dialog.h
+++ b/src/filebrowser/progress-dialog.h
@@ -33,7 +33,7 @@ private slots:
     void initTaskInfo();
     void onOneFileUploadFailed(const QString& filename, bool single_file);
     void onQueryUpdate();
-    void onQuerySuccess(const GetIndexProgressResult& result);
+    void onQuerySuccess(const ServerIndexProgress& result);
     ActionOnFailure retryOrSkipOrAbort(const QString& msg, bool single_file);
 
 private:

--- a/src/filebrowser/reliable-upload.cpp
+++ b/src/filebrowser/reliable-upload.cpp
@@ -11,7 +11,6 @@
 #include <QSslError>
 #include <QSslConfiguration>
 #include <QSslCertificate>
-#include <QUrlQuery>
 
 #include "utils/utils.h"
 #include "utils/file-utils.h"

--- a/src/filebrowser/reliable-upload.cpp
+++ b/src/filebrowser/reliable-upload.cpp
@@ -432,17 +432,11 @@ void PostFileTask::sendRequest()
     multipart->append(file_part);
 
     // "need_idx_progress" param
-    QUrl need_idx_url = url_;
     if (need_idx_progress_) {
-        QUrlQuery query;
-        QString key = "need_idx_progress";
-        QString value = "true";
-        query.addQueryItem(QUrl::toPercentEncoding(key),
-                           QUrl::toPercentEncoding(value));
-        need_idx_url.setQuery(query);
+        url_ = ::includeQueryParams(url_, {{"need_idx_progress", "true"}});
     }
 
-    QNetworkRequest request(need_idx_url);
+    QNetworkRequest request(url_);
     request.setRawHeader("Content-Type",
                          "multipart/form-data; boundary=" + multipart->boundary());
     if (isChunked()) {

--- a/src/filebrowser/reliable-upload.h
+++ b/src/filebrowser/reliable-upload.h
@@ -85,6 +85,7 @@ private:
     bool resumable_;
     quint64 current_offset_;
     quint32 current_chunk_size_;
+    bool need_idx_progress_;
 
     // The underlying task that sends the POST file request
     QScopedPointer<PostFileTask, doDeleteLater<PostFileTask> > task_;
@@ -115,7 +116,8 @@ private:
                  const bool use_upload,
                  quint64 total_size,
                  quint64 start_offset,
-                 quint32 chunk_size);
+                 quint32 chunk_size,
+                 const bool need_idx_progress);
 
     PostFileTask(const QUrl& url,
                  const QString& parent_dir,
@@ -138,6 +140,7 @@ private:
 
     quint64 start_offset_;
     qint32 chunk_size_;
+    bool need_idx_progress_;
 };
 
 #endif // SEAFILE_CLIETN_FILEBROWSER_TAKS_H

--- a/src/filebrowser/tasks.cpp
+++ b/src/filebrowser/tasks.cpp
@@ -196,6 +196,7 @@ void FileNetworkTask::onFileServerTaskFinished(bool success)
         failed_path_ = fileserver_task_->failedPath();
     }
     oid_ = fileserver_task_->oid();
+    url_ = fileserver_task_->url();
     onFinished(success);
 }
 

--- a/src/filebrowser/tasks.h
+++ b/src/filebrowser/tasks.h
@@ -80,6 +80,7 @@ public:
     QString failedPath() const { return failed_path_; }
     QString fileName() const;
     QString oid() const { return oid_; }
+    QUrl url() const { return url_; }
     Progress progress() const { return progress_; };
     bool canceled() const { return canceled_; }
 
@@ -125,6 +126,7 @@ protected:
     QString local_path_;
     QString failed_path_;
     QString oid_;
+    QUrl url_;
 
     TaskError error_;
     QString error_string_;
@@ -286,6 +288,7 @@ public:
     int retryCount() const { return retry_count_; }
     const QString& failedPath() const { return failed_path_; }
     bool canceled() const { return canceled_; }
+    QUrl url() const { return url_; }
 
     static void resetQNAM();
 


### PR DESCRIPTION
<img width="588" alt="2018-01-31 5 54 32" src="https://user-images.githubusercontent.com/32261840/35671159-80edbb06-0775-11e8-95c1-4885a47cfb4b.png">

支持上传文件时服务器异步保存

- 只在上传单个文件时有效
- 服务器返回一个 task progress id, 客户端用这个 id 去查询
- 通过服务器返回的 id 中是否包含 "-" 来同时兼容新老版本的服务器 
