### PR TITLE
Cloud View always failed to search

### DIFF
--- a/src/api/requests.cpp
+++ b/src/api/requests.cpp
@@ -820,7 +820,9 @@ FileSearchRequest::FileSearchRequest(const Account& account,
     }
     // per_page = 2;
     setUrlParam("per_page", QString::number(per_page));
-    setUrlParam("search_repo", repo_id);
+    if (!repo_id.isEmpty()) {
+        setUrlParam("search_repo", repo_id);
+    }
 }
 
 void FileSearchRequest::requestSuccess(QNetworkReply& reply)


### PR DESCRIPTION
云端浏览器做搜索功能时，导致主界面的搜索tab请求参数不匹配，搜索结果总是失败