### PR TITLE
Generic function as slot function warning message

### DIFF
--- a/src/account-mgr.h
+++ b/src/account-mgr.h
@@ -71,8 +71,6 @@ public:
     // invalidate current login and emit a re-login signal
     void invalidateCurrentLogin();
 
-    bool reloginAccount(const Account &account);
-
     void getSyncedReposToken(const Account& account);
 
 signals:
@@ -86,6 +84,9 @@ signals:
 
     void requireAddAccount();
     void accountInfoUpdated(const Account& account);
+
+public slots:
+    bool reloginAccount(const Account &account);
 
 private slots:
     void serverInfoSuccess(const Account &account, const ServerInfo &info);


### PR DESCRIPTION
客户端启动时，日志中会有这么一条信息：[05/22/18 18:06:23]QObject::connect: No such slot AccountManager::reloginAccount(const Account &)