### PR TITLE
Failed to upload and retry ,need to get uploadlink again

### DIFF
--- a/src/filebrowser/reliable-upload.cpp
+++ b/src/filebrowser/reliable-upload.cpp
@@ -244,7 +244,7 @@ void ReliablePostFileTask::handlePostFileTaskFailure()
     }
 }
 
-void ReliablePostFileTask::continueWithFailedFile(bool retry)
+void ReliablePostFileTask::continueWithFailedFile(bool retry, const QString& link)
 {
     // retry=false is only for PostFilesTask
     assert(retry);

--- a/src/filebrowser/reliable-upload.h
+++ b/src/filebrowser/reliable-upload.h
@@ -40,7 +40,7 @@ public:
     ~ReliablePostFileTask();
 
     virtual const QString &oid() const;
-    virtual void continueWithFailedFile(bool retry);
+    virtual void continueWithFailedFile(bool retry, const QString& link);
 
 public slots:
     void cancel();

--- a/src/filebrowser/tasks.cpp
+++ b/src/filebrowser/tasks.cpp
@@ -300,7 +300,18 @@ void FileUploadTask::onOneFileFailed(const QString& filename, bool single_file)
 
 void FileUploadTask::continueWithFailedFile(bool retry)
 {
-    fileserver_task_->continueWithFailedFile(retry);
+    retry_ = retry;
+    createGetLinkRequest();
+    connect(get_link_req_, SIGNAL(success(const QString&)),
+            this, SLOT(onLinkGetAgain(const QString&)));
+    connect(get_link_req_, SIGNAL(failed(const ApiError&)),
+            this, SLOT(onGetLinkFailed(const ApiError&)));
+    get_link_req_->send();
+}
+
+void FileUploadTask::onLinkGetAgain(const QString& link)
+{
+    fileserver_task_->continueWithFailedFile(retry_, link);
 }
 
 FileUploadMultipleTask::FileUploadMultipleTask(const Account& account,
@@ -772,7 +783,7 @@ void PostFilesTask::onPostTaskFinished(bool success)
     startNext();
 }
 
-void PostFilesTask::startNext()
+void PostFilesTask::startNext(const QString& link)
 {
     progress_update_timer_->stop();
     if (++current_num_ == names_.size()) {
@@ -788,6 +799,9 @@ void PostFilesTask::startNext()
         relative_path = ::pathJoin(QFileInfo(local_path_).fileName(), ::getParentPath(file_path));
 
     // relative_path might be empty, and should be safe to use as well
+    if (!link.isEmpty()) {
+        url_ = link;
+    }
     task_.reset(new ReliablePostFileTask(url_,
         parent_dir_,
         ::pathJoin(local_path_, file_path),
@@ -802,7 +816,7 @@ void PostFilesTask::startNext()
     task_->start();
 }
 
-void PostFilesTask::continueWithFailedFile(bool retry)
+void PostFilesTask::continueWithFailedFile(bool retry, const QString& link)
 {
     if (retry) {
         current_num_--;
@@ -812,7 +826,7 @@ void PostFilesTask::continueWithFailedFile(bool retry)
         // successfully.
         transferred_bytes_ += file_sizes_[current_num_];
     }
-    startNext();
+    startNext(link);
 }
 
 void FileServerTask::setError(FileNetworkTask::TaskError error,

--- a/src/filebrowser/tasks.h
+++ b/src/filebrowser/tasks.h
@@ -202,6 +202,7 @@ signals:
 protected slots:
     // Here
     virtual void onOneFileFailed(const QString& filename, bool single_file);
+    void onLinkGetAgain(const QString& link);
 
 protected:
     virtual void startFileServerTask(const QString& link);
@@ -215,6 +216,7 @@ private:
     FileUploadTask &operator=(const FileUploadTask& rhs);
 
     const bool use_upload_;
+    bool retry_;
 };
 
 class FileUploadMultipleTask : public FileUploadTask {
@@ -278,7 +280,7 @@ public:
                    const QString& local_path);
     virtual ~FileServerTask();
 
-    virtual void continueWithFailedFile(bool retry) {};
+    virtual void continueWithFailedFile(bool retry, const QString& link) {};
 
     // accessors
     const FileNetworkTask::TaskError& error() const { return error_; }
@@ -389,12 +391,12 @@ public:
 
     const QStringList& successfulNames() const { return successful_names_; }
 
-    void continueWithFailedFile(bool retry);
+    void continueWithFailedFile(bool retry, const QString& link);
 
 protected:
     void prepare();
     void sendRequest();
-    void startNext();
+    void startNext(const QString& link = QString());
 
 private slots:
     void cancel();


### PR DESCRIPTION
Failed to upload a single file. After selecting "Retry" and "Skip", you need to retrieve the upload link again.