### PR TITLE
2FA: use OK as default button

### DIFF
--- a/ui/two-factor-dialog.ui
+++ b/ui/two-factor-dialog.ui
@@ -77,6 +77,9 @@
        <property name="text">
         <string>OK</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
I've got no dev env but according to http://doc.qt.io/archives/qt-4.8/qpushbutton.html#default-prop this should fix #1126