### PR TITLE
update seafilelink dialog

### DIFF
--- a/src/ext-handler.cpp
+++ b/src/ext-handler.cpp
@@ -188,16 +188,17 @@ void SeafileExtensionHandler::generateShareLink(const QString& repo_id,
         return;
     }
 
+    repo_id_ = repo_id;
     if (internal) {
-        QString path = path_in_repo;
-        if (!is_file && !path.endsWith("/")) {
-            path += "/";
+        path_ = path_in_repo;
+        if (!is_file && !path_.endsWith("/")) {
+            path_ += "/";
         }
-        SeafileLinkDialog *dialog = new SeafileLinkDialog(repo_id, account, path, NULL);
-        dialog->setAttribute(Qt::WA_DeleteOnClose);
-        dialog->show();
-        dialog->raise();
-        dialog->activateWindow();
+        GetSmartLinkRequest *req = new GetSmartLinkRequest(account, repo_id_, path_, !is_file);
+        connect(req, SIGNAL(success(const QString&)),
+                this, SLOT(onGetSmartLinkSuccess(const QString&)));
+
+        req->send();
     } else {
         GetSharedLinkRequest *req = new GetSharedLinkRequest(
             account, repo_id, path_in_repo, is_file);
@@ -207,6 +208,16 @@ void SeafileExtensionHandler::generateShareLink(const QString& repo_id,
 
         req->send();
     }
+}
+
+void SeafileExtensionHandler::onGetSmartLinkSuccess(const QString& smart_link)
+{
+    const Account account = seafApplet->accountManager()->getAccountByRepo(repo_id_);
+    SeafileLinkDialog *dialog = new SeafileLinkDialog(repo_id_, account, path_, smart_link, NULL);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->show();
+    dialog->raise();
+    dialog->activateWindow();
 }
 
 void SeafileExtensionHandler::lockFile(const QString& repo_id,

--- a/src/ext-handler.h
+++ b/src/ext-handler.h
@@ -44,13 +44,12 @@ private slots:
                       bool to_group);
     void openUrlWithAutoLogin(const QUrl& url);
     void onGetSmartLinkSuccess(const QString& smart_link);
+    void onGetSmartLinkFailed(const ApiError& error);
 
 private:
     ExtConnectionListenerThread *listener_thread_;
 
     bool started_;
-    QString repo_id_;
-    QString path_;
 };
 
 /**

--- a/src/ext-handler.h
+++ b/src/ext-handler.h
@@ -43,11 +43,14 @@ private slots:
                       const QString& path_in_repo,
                       bool to_group);
     void openUrlWithAutoLogin(const QUrl& url);
+    void onGetSmartLinkSuccess(const QString& smart_link);
 
 private:
     ExtConnectionListenerThread *listener_thread_;
 
     bool started_;
+    QString repo_id_;
+    QString path_;
 };
 
 /**

--- a/src/filebrowser/file-browser-dialog.cpp
+++ b/src/filebrowser/file-browser-dialog.cpp
@@ -1233,11 +1233,26 @@ void FileBrowserDialog::onGetDirentShareSeafile(const SeafDirent& dirent)
 {
     QString repo_id = repo_.id;
     QString email = account_.username;
-    QString path = ::pathJoin(current_path_, dirent.name);
+    path_ = ::pathJoin(current_path_, dirent.name);
     if (dirent.isDir())
-        path += "/";
+        path_ += "/";
+    GetSmartLinkRequest *req = new GetSmartLinkRequest(account_, repo_id, path_, dirent.isDir());
+    connect(req, SIGNAL(success(const QString&)),
+            this, SLOT(onGetSmartLinkSuccess(const QString&)));
+    connect(req, SIGNAL(failed(const ApiError&)),
+            this, SLOT(onGetSmartLinkFailed(const ApiError&)));
 
-    SeafileLinkDialog(repo_id, account_, path, this).exec();
+    req->send();
+}
+
+void FileBrowserDialog::onGetSmartLinkSuccess(const QString& smart_link)
+{
+    SeafileLinkDialog(repo_.id, account_, path_, smart_link, this).exec();
+}
+
+void FileBrowserDialog::onGetSmartLinkFailed(const ApiError& error)
+{
+    qWarning("get smart_link failed %s\n", error.toString().toUtf8().data());
 }
 
 void FileBrowserDialog::onDirectoryCreateSuccess(const QString &path)

--- a/src/filebrowser/file-browser-dialog.cpp
+++ b/src/filebrowser/file-browser-dialog.cpp
@@ -1233,10 +1233,10 @@ void FileBrowserDialog::onGetDirentShareSeafile(const SeafDirent& dirent)
 {
     QString repo_id = repo_.id;
     QString email = account_.username;
-    path_ = ::pathJoin(current_path_, dirent.name);
+    QString path = ::pathJoin(current_path_, dirent.name);
     if (dirent.isDir())
-        path_ += "/";
-    GetSmartLinkRequest *req = new GetSmartLinkRequest(account_, repo_id, path_, dirent.isDir());
+        path += "/";
+    GetSmartLinkRequest *req = new GetSmartLinkRequest(account_, repo_id, path, dirent.isDir());
     connect(req, SIGNAL(success(const QString&)),
             this, SLOT(onGetSmartLinkSuccess(const QString&)));
     connect(req, SIGNAL(failed(const ApiError&)),
@@ -1247,7 +1247,7 @@ void FileBrowserDialog::onGetDirentShareSeafile(const SeafDirent& dirent)
 
 void FileBrowserDialog::onGetSmartLinkSuccess(const QString& smart_link)
 {
-    SeafileLinkDialog(repo_.id, account_, path_, smart_link, this).exec();
+    SeafileLinkDialog(smart_link, this).exec();
 }
 
 void FileBrowserDialog::onGetSmartLinkFailed(const ApiError& error)

--- a/src/filebrowser/file-browser-dialog.h
+++ b/src/filebrowser/file-browser-dialog.h
@@ -149,6 +149,8 @@ private slots:
                          bool has_more);
     void onSearchFailed(const ApiError& error);
 
+    void onGetSmartLinkSuccess(const QString& smart_link);
+    void onGetSmartLinkFailed(const ApiError& error);
 private:
     Q_DISABLE_COPY(FileBrowserDialog)
 
@@ -249,6 +251,10 @@ private:
 
     // Avoid showing multiple SetRepoPasswordDialog
     bool has_password_dialog_;
+
+    //seafilelink
+    QString repo_id_;
+    QString path_;
 };
 
 class DataManagerNotify : public QObject {

--- a/src/filebrowser/file-browser-dialog.h
+++ b/src/filebrowser/file-browser-dialog.h
@@ -251,10 +251,6 @@ private:
 
     // Avoid showing multiple SetRepoPasswordDialog
     bool has_password_dialog_;
-
-    //seafilelink
-    QString repo_id_;
-    QString path_;
 };
 
 class DataManagerNotify : public QObject {

--- a/src/filebrowser/file-browser-requests.h
+++ b/src/filebrowser/file-browser-requests.h
@@ -368,4 +368,25 @@ private:
     Q_DISABLE_COPY(GetIndexProgressRequest);
 };
 
+class GetSmartLinkRequest : public SeafileApiRequest
+{
+    Q_OBJECT
+public:
+    GetSmartLinkRequest(const Account& account,
+                        const QString& repo_id,
+                        const QString& path,
+                        bool is_dir);
+
+signals:
+    void success(const QString& smart_link);
+
+protected slots:
+    void requestSuccess(QNetworkReply& reply);
+
+private:
+    Q_DISABLE_COPY(GetSmartLinkRequest);
+    QString repo_id_;
+    QString path_;
+    bool is_dir_;
+};
 #endif  // SEAFILE_CLIENT_FILE_BROWSER_REQUESTS_H

--- a/src/filebrowser/seafilelink-dialog.cpp
+++ b/src/filebrowser/seafilelink-dialog.cpp
@@ -7,9 +7,8 @@
 #include "utils/utils-mac.h"
 #include "open-local-helper.h"
 
-SeafileLinkDialog::SeafileLinkDialog(const QString& repo_id, const Account& account, const QString& path, QWidget *parent)
-    : web_link_(OpenLocalHelper::instance()->generateLocalFileWebUrl(repo_id, account, path).toEncoded())
-    , protocol_link_(OpenLocalHelper::instance()->generateLocalFileSeafileUrl(repo_id, account, path).toEncoded())
+SeafileLinkDialog::SeafileLinkDialog(const QString& repo_id, const Account& account, const QString& path, const QString& smart_link, QWidget *parent)
+    :web_link_(smart_link)
 {
     setWindowTitle(tr("%1 Internal Link").arg(getBrand()));
     setWindowIcon(QIcon(":/images/seafile.png"));
@@ -25,7 +24,7 @@ SeafileLinkDialog::SeafileLinkDialog(const QString& repo_id, const Account& acco
     //
     // create web link related
     //
-    QLabel *web_label = new QLabel(tr("%1 Web Link:").arg(getBrand()));
+    QLabel *web_label = new QLabel(tr("%1 Internal Link:").arg(getBrand()));
     layout->addWidget(web_label);
     QHBoxLayout *web_layout = new QHBoxLayout;
 
@@ -47,24 +46,24 @@ SeafileLinkDialog::SeafileLinkDialog(const QString& repo_id, const Account& acco
     //
     // create seafile-protocol link related
     //
-    QLabel *protocol_label = new QLabel(tr("%1 Protocol Link:").arg(getBrand()));
-    layout->addWidget(protocol_label);
-    QHBoxLayout *protocol_layout = new QHBoxLayout;
+//    QLabel *protocol_label = new QLabel(tr("%1 Protocol Link:").arg(getBrand()));
+//    layout->addWidget(protocol_label);
+//    QHBoxLayout *protocol_layout = new QHBoxLayout;
 
-    protocol_editor_ = new QLineEdit;
-    protocol_editor_->setText(protocol_link_);
-    protocol_editor_->selectAll();
-    protocol_editor_->setReadOnly(true);
-    protocol_editor_->setCursorPosition(0);
+//    protocol_editor_ = new QLineEdit;
+//    protocol_editor_->setText(protocol_link_);
+//    protocol_editor_->selectAll();
+//    protocol_editor_->setReadOnly(true);
+//    protocol_editor_->setCursorPosition(0);
 
-    protocol_layout->addWidget(protocol_editor_);
+//    protocol_layout->addWidget(protocol_editor_);
 
-    QPushButton *protocol_copy_to = new QPushButton;
-    protocol_copy_to->setIcon(copy_to_icon);
-    protocol_copy_to->setToolTip(copy_to_str);
-    protocol_layout->addWidget(protocol_copy_to);
-    connect(protocol_copy_to, SIGNAL(clicked()), this, SLOT(onCopyProtocolText()));
-    layout->addLayout(protocol_layout);
+//    QPushButton *protocol_copy_to = new QPushButton;
+//    protocol_copy_to->setIcon(copy_to_icon);
+//    protocol_copy_to->setToolTip(copy_to_str);
+//    protocol_layout->addWidget(protocol_copy_to);
+//    connect(protocol_copy_to, SIGNAL(clicked()), this, SLOT(onCopyProtocolText()));
+//    layout->addLayout(protocol_layout);
 
     QHBoxLayout *hlayout = new QHBoxLayout;
 

--- a/src/filebrowser/seafilelink-dialog.cpp
+++ b/src/filebrowser/seafilelink-dialog.cpp
@@ -7,7 +7,7 @@
 #include "utils/utils-mac.h"
 #include "open-local-helper.h"
 
-SeafileLinkDialog::SeafileLinkDialog(const QString& repo_id, const Account& account, const QString& path, const QString& smart_link, QWidget *parent)
+SeafileLinkDialog::SeafileLinkDialog(const QString& smart_link, QWidget *parent)
     :web_link_(smart_link)
 {
     setWindowTitle(tr("%1 Internal Link").arg(getBrand()));

--- a/src/filebrowser/seafilelink-dialog.h
+++ b/src/filebrowser/seafilelink-dialog.h
@@ -8,14 +8,14 @@ class SeafileLinkDialog : public QDialog
 {
     Q_OBJECT
 public:
-    SeafileLinkDialog(const QString& repo_id, const Account& account, const QString& path, QWidget *parent = NULL);
+    SeafileLinkDialog(const QString& repo_id, const Account& account, const QString& path, const QString& smart_link, QWidget *parent = NULL);
 
 private slots:
     void onCopyWebText();
     void onCopyProtocolText();
 
 private:
-    const QString web_link_;
+    QString web_link_;
     const QString protocol_link_;
     QLineEdit *web_editor_;
     QLineEdit *protocol_editor_;

--- a/src/filebrowser/seafilelink-dialog.h
+++ b/src/filebrowser/seafilelink-dialog.h
@@ -8,7 +8,7 @@ class SeafileLinkDialog : public QDialog
 {
     Q_OBJECT
 public:
-    SeafileLinkDialog(const QString& repo_id, const Account& account, const QString& path, const QString& smart_link, QWidget *parent = NULL);
+    SeafileLinkDialog(const QString& smart_link, QWidget *parent = NULL);
 
 private slots:
     void onCopyWebText();

--- a/src/finder-sync/finder-sync-host.cpp
+++ b/src/finder-sync/finder-sync-host.cpp
@@ -196,13 +196,15 @@ void FinderSyncHost::doShareLink(const QString &path) {
 
 void FinderSyncHost::doInternalLink(const QString &path)
 {
+    QString repo_id;
     Account account;
-    if (!lookUpFileInformation(path, &repo_id_, &account, &path_in_repo_)) {
+    QString path_in_repo;
+    if (!lookUpFileInformation(path, &repo_id, &account, &path_in_repo)) {
         qWarning("[FinderSync] invalid path %s", path.toUtf8().data());
         return;
     }
 
-    GetSmartLinkRequest *req = new GetSmartLinkRequest(account, repo_id_, path_in_repo_, path_in_repo_.endsWith('/'));
+    GetSmartLinkRequest *req = new GetSmartLinkRequest(account, repo_id, path_in_repo, path_in_repo.endsWith('/'));
     connect(req, SIGNAL(success(const QString&)),
             this, SLOT(onGetSmartLinkSuccess(const QString&)));
     connect(req, SIGNAL(failed(const ApiError&)),
@@ -214,8 +216,7 @@ void FinderSyncHost::doInternalLink(const QString &path)
 
 void FinderSyncHost::onGetSmartLinkSuccess(const QString& smart_link)
 {
-    Account account;
-    SeafileLinkDialog *dialog = new SeafileLinkDialog(repo_id_, account, path_in_repo_, smart_link);
+    SeafileLinkDialog *dialog = new SeafileLinkDialog(smart_link);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
     dialog->raise();

--- a/src/finder-sync/finder-sync-host.h
+++ b/src/finder-sync/finder-sync-host.h
@@ -35,8 +35,6 @@ private slots:
 private:
     bool lookUpFileInformation(const QString &path, QString *repo_id, Account *account, QString *path_in_repo);
     SeafileRpcClient *rpc_client_;
-    QString repo_id_;
-    QString path_in_repo_;
 };
 
 #endif // SEAFILE_CLIENT_FINDER_SYNC_HOST_H_

--- a/src/finder-sync/finder-sync-host.h
+++ b/src/finder-sync/finder-sync-host.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <vector>
 #include "utils/stl.h"
+#include "api/api-error.h"
 
 const int kWatchDirMax = 100;
 const int kPathMaxSize = 1024;
@@ -29,9 +30,13 @@ private slots:
     void onShareLinkGenerated(const QString& link);
     void onLockFileSuccess();
     void doShowFileHistory(const QString& path);
+    void onGetSmartLinkSuccess(const QString& smart_link);
+    void onGetSmartLinkFailed(const ApiError& error);
 private:
     bool lookUpFileInformation(const QString &path, QString *repo_id, Account *account, QString *path_in_repo);
     SeafileRpcClient *rpc_client_;
+    QString repo_id_;
+    QString path_in_repo_;
 };
 
 #endif // SEAFILE_CLIENT_FINDER_SYNC_HOST_H_


### PR DESCRIPTION
1、对应web端的“获取内部链接”增加了一个GetSmartLinkRequest请求
2、file-browser-dialog/finder-sync-host/ext-handler中“获取内部链接”前先请求smart-link
3、seaflink-dialog中只展示smart-link
<img width="453" alt="2018-09-12 3 43 40" src="https://user-images.githubusercontent.com/32261840/45409902-0be0b380-b6a3-11e8-9e46-03a33468cc42.png">
