### PR TITLE
Update macOS dependency installation script for Qt 5 support

### DIFF
--- a/scripts/install-deps-osx.sh
+++ b/scripts/install-deps-osx.sh
@@ -4,7 +4,7 @@ set -e
 ## TODO: use the correct version of seafile for each branch
 
 brew up
-brew install qt4
+brew install qt
 
 brew tap Chilledheart/seafile
 brew install --HEAD libsearpc ccnet seafile


### PR DESCRIPTION
As Qt 5 is necessary for building seafile client on macOS the script now installs the appropriate version.