### PR TITLE
[fix] Automatic long checkbox is constantly checked

### DIFF
--- a/src/ui/login-dialog.cpp
+++ b/src/ui/login-dialog.cpp
@@ -128,6 +128,7 @@ void LoginDialog::initFromAccount(const Account& account)
     mServerAddr->setCurrentIndex(0);
     mServerAddr->setEditable(false);
 
+    mAutomaticLogin->setCheckState(account.isAutomaticLogin ? Qt::Checked : Qt::Unchecked);
     mUsername->setText(account.username);
     mPassword->setFocus(Qt::OtherFocusReason);
 }


### PR DESCRIPTION
On login dialog Automatic logon checkbox is constantly checked.