### PR TITLE
add libressl >= 2.7 support

### DIFF
--- a/src/utils/rsa.cpp
+++ b/src/utils/rsa.cpp
@@ -13,7 +13,7 @@ namespace {
 
 /* Forward compatibility functions if libssl < 1.1.0. */
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 {


### PR DESCRIPTION
Hi,
Actually seafile-client isn’t able to build against LibreSSL >= 2.7.
With that condition changed, it can now build.
Since v2.7, LibreSSL supports OpenSSL 1.1 APIs.