### PR TITLE
Fix compilation errors with glib2 >= 2.67.3

### DIFF
--- a/src/open-local-helper.cpp
+++ b/src/open-local-helper.cpp
@@ -7,7 +7,6 @@
 #include <QUrlQuery>
 #include <QVariant>
 
-extern "C" {
 #include <searpc-client.h>
 
 #include <searpc.h>
@@ -18,8 +17,6 @@ extern "C" {
 #include <seafile/seafile.h>
 #include <seafile/seafile-object.h>
 #endif
-
-}
 
 #include "utils/utils.h"
 #include "seafile-applet.h"

--- a/src/rpc/rpc-client.cpp
+++ b/src/rpc/rpc-client.cpp
@@ -1,5 +1,3 @@
-extern "C" {
-
 #include <searpc-client.h>
 #include <searpc-named-pipe-transport.h>
 
@@ -11,8 +9,6 @@ extern "C" {
 #include <seafile/seafile.h>
 #include <seafile/seafile-object.h>
 #endif
-
-}
 
 #include <QtDebug>
 #include <QMutexLocker>

--- a/src/rpc/rpc-client.h
+++ b/src/rpc/rpc-client.h
@@ -6,13 +6,9 @@
 #include <QObject>
 #include <QMutex>
 
-extern "C" {
-
 struct _GList;
 // Can't forward-declare type SearpcClient here because it is an anonymous typedef struct
 #include <searpc-client.h>
-
-}
 
 // Here we can't forward-declare type json_t because it is an anonymous typedef
 // struct, and unlike libsearpc we have no way to rewrite its definition to give

--- a/src/rpc/rpc-server.cpp
+++ b/src/rpc/rpc-server.cpp
@@ -1,9 +1,9 @@
-extern "C" {
-
 #include <searpc.h>
 #include <searpc-client.h>
 #include <searpc-server.h>
 #include <searpc-named-pipe-transport.h>
+
+extern "C" {
 
 #include "searpc-signature.h"
 #include "searpc-marshal.h"

--- a/src/utils/uninstall-helpers.cpp
+++ b/src/utils/uninstall-helpers.cpp
@@ -1,4 +1,3 @@
-extern "C" {
 #include <searpc-client.h>
 
 #include <searpc.h>
@@ -9,8 +8,6 @@ extern "C" {
 #include <seafile/seafile.h>
 #include <seafile/seafile-object.h>
 #endif
-
-}
 
 #include <QtGlobal>
 


### PR DESCRIPTION
Glib release 2.67.3 has introduced a fragment of C++ code (guarded with `#ifdef __cplusplus`) in glib headers[1]. Starting from this version it's no longer legal to include glib headers (or anything that transitively includes those) from within `extern "C"` block. Seafile-client and seadrive-gui are both affected by that due to a transitive inclusion of glib headers via libsearpc. 

Example log with compilation errors: 
https://copr-be.cloud.fedoraproject.org/results/alebastr/seafile-client/fedora-rawhide-x86_64/01963551-seafile-client/build.log.gz

Glib issue: https://gitlab.gnome.org/GNOME/glib/-/issues/2331 (closed as wontfix)

Distributions with affected glib version: Fedora Rawhide, Debian Experimental, Gentoo

**Depends on**: https://github.com/haiwen/libsearpc/pull/57, https://github.com/haiwen/seafile/pull/2428
**Important note**: the change here won't even compile without the PRs above so that may require tagging new release for libsearpc.

***

The recommended way of addressing this is to apply the following changes:
1. In `libsearpc`, use G_BEGIN_DECLS/G_END_DECLS in public headers as recommended by the glib developer documentation[2]:
I.e., `searpc-client.h` could be changed like that:
```C++
#ifndef SEARPC_CLIENT_H
#define SEARPC_CLIENT_H

#ifdef LIBSEARPC_EXPORTS
#define LIBSEARPC_API __declspec(dllexport)
#else
#define LIBSEARPC_API
#endif

#include <glib.h>
#include <glib-object.h>
#include <jansson.h>

#ifndef DFT_DOMAIN
#define DFT_DOMAIN g_quark_from_string(G_LOG_DOMAIN)
#endif

G_BEGIN_DECLS

// ...types, method declarations and other symbols...

G_END_DECLS

#endif
```

2. Apply similar changes to the `seafile` public headers.

3. In `seafile-client` and `seadrive-gui` projects, remove `extern "C"` blocks around all `#include`s with `libsearpc`, `seafile` or `glib` headers.

The alternative workaround is to include `<glib.h>` before each affected `extern "C"` block.

[1]: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1715
[2]: https://developer.gnome.org/gobject/stable/howto-gobject.html#howto-gobject-header
