### PR TITLE
Added minor changes to get it to compile on Apple M1

### DIFF
--- a/seafile-applet.entitlements
+++ b/seafile-applet.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/src/ui/events-list-view.cpp
+++ b/src/ui/events-list-view.cpp
@@ -1,10 +1,10 @@
 #include <QPainter>
+#include <QPainterPath>
 #include <QApplication>
 #include <QPixmap>
 #include <QToolTip>
 #include <QLayout>
 #include <QDebug>
-
 #include "seafile-applet.h"
 #include "main-window.h"
 #include "events-service.h"

--- a/src/ui/private-share-dialog.cpp
+++ b/src/ui/private-share-dialog.cpp
@@ -2,6 +2,7 @@
 #include <QCompleter>
 #include <QLineEdit>
 #include <QPainter>
+#include <QPainterPath>
 #include <QResizeEvent>
 #include <QStringList>
 #include <QStringListModel>


### PR DESCRIPTION
With the buildpath I'm outlining [here](https://forum.seafile.com/t/native-support-for-apple-silicon/13390/12) in order to compile for the Apple M1 you need to use the homebrew qt@5 formula instead of qt 5.6. In order to do that, very minor changes need to be done just to change updated dependencies.

These changes certainly don't need to be merged if you find another way to build for the M!, but I'm making this for visibility. 

The changes to seafile-applet.entitlements probably aren't necessary in the official buildpath but are for anyone who wants to self-sign their executable through xcode.