### PR TITLE
Add CHACHA20-POLY1305 ciphers to whiltelist

### DIFF
--- a/src/network-mgr.cpp
+++ b/src/network-mgr.cpp
@@ -27,6 +27,8 @@ inline size_t ArrayLengthOf(T (&)[N]) {
 }
 
 const char *const kWhitelistCiphers[] = {
+    "ECDHE-ECDSA-CHACHA20-POLY1305"
+    "ECDHE-RSA-CHACHA20-POLY1305"
     "ECDHE-RSA-AES256-GCM-SHA384"
     "ECDHE-RSA-AES128-GCM-SHA256"
     "DHE-RSA-AES256-GCM-SHA384"


### PR DESCRIPTION
Following from #1372. TLDR: ChaCha20 is much faster for devices that do not provide hardware AES acceleration (eg. Raspberry Pi 4), and secure to the point of being included in TLS1.3. [The Mozilla Wiki provides a list](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29) of secure cipher suites, and the ones added here are listed there as secure.

I'm confused as to why this would need to be added if ``isWeakCipher`` works as I think it does. Many of the additions to the whitelist seem to be unnecessary, maybe ``isWeakCipher`` is not actually working as expected? Feedback is much appreciated!