### PR TITLE
Properly change settings button icon on hover (fix #1379)

### DIFF
--- a/qt.css
+++ b/qt.css
@@ -713,11 +713,12 @@ AccountView QPushButton#mSettingsPushButton {
     border: 0;
     border-radius: 0;
     icon-size: 20px;
+    image: url(:/images/toolbar/settings.png);
 }
 
 AccountView QPushButton:hover#mSettingsPushButton {
     border: 0;
     border-radius: 0;
     icon-size: 20px;
-    icon: url(:/images/toolbar/settings-orange.png);
+    image: url(:/images/toolbar/settings-orange.png);
 }

--- a/src/ui/account-view.cpp
+++ b/src/ui/account-view.cpp
@@ -66,7 +66,6 @@ AccountView::AccountView(QWidget *parent)
     // automatically.
     mRefreshLabel->setPixmap(QIcon(":/images/toolbar/refresh-new.png").pixmap(20));
     mRefreshLabel->installEventFilter(this);
-    mSettingsPushButton->setIcon(QIcon(":/images/toolbar/settings.png"));
     connect(mSettingsPushButton, &QPushButton::clicked, this, &AccountView::slotShowSettingsDialog);
 }
 


### PR DESCRIPTION
Hovering over the settings button can lead to a segfault because of the `icon` property using QT 5.15.3. 

This fixes the issue by using `image` property to change the icon on hover. To avoid layering issues, the default icon is also set through css.

Fixes #1379 