### PR TITLE
Add "Toggle tray icon color" to macOS

### DIFF
--- a/i18n/seafile_en.ts
+++ b/i18n/seafile_en.ts
@@ -2688,6 +2688,10 @@ File path contains invalid characters. It is not synced to this computer.</sourc
         <source>have some sync error</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle tray icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SearchResultListView</name>

--- a/src/settings-mgr.cpp
+++ b/src/settings-mgr.cpp
@@ -30,6 +30,9 @@ namespace
 const char *kHideMainWindowWhenStarted = "hideMainWindowWhenStarted";
 const char *kHideDockIcon = "hideDockIcon";
 const char *kEnableSyncingWithExistingFolder = "syncingWithExistingFolder";
+#if defined(Q_OS_MACOS)
+const char *kTrayIconDark = "trayIconDark";
+#endif
 const char *kBehaviorGroup = "Behavior";
 
 // const char *kDefaultLibraryAlreadySetup = "defaultLibraryAlreadySetup";
@@ -573,6 +576,25 @@ void SettingsManager::setEnableSyncingWithExistingFolder(bool enabled)
     settings.setValue(kEnableSyncingWithExistingFolder, enabled);
     settings.endGroup();
 }
+
+#if defined(Q_OS_MACOS)
+void SettingsManager::toggleTrayIconColor()
+{
+    QSettings settings;
+    settings.beginGroup(kBehaviorGroup);
+    // dark should be false by default
+    settings.setValue(kTrayIconDark, !settings.value(kTrayIconDark, false).toBool());
+    settings.endGroup();
+}
+
+bool SettingsManager::isTrayIconDark(){
+    QSettings settings;
+    settings.beginGroup(kBehaviorGroup);
+    bool dark = settings.value(kTrayIconDark, false).toBool();
+    settings.endGroup();
+    return dark;
+}
+#endif
 
 QString SettingsManager::getComputerName()
 {

--- a/src/settings-mgr.h
+++ b/src/settings-mgr.h
@@ -97,6 +97,11 @@ public:
     bool isEnableSyncingWithExistingFolder() const;
     void setEnableSyncingWithExistingFolder(bool enabled);
 
+#if defined(Q_OS_MACOS)
+    void toggleTrayIconColor();
+    bool isTrayIconDark();
+#endif
+
 #ifdef HAVE_SHIBBOLETH_SUPPORT
     QString getLastShibUrl();
     void setLastShibUrl(const QString& url);

--- a/src/ui/tray-icon.cpp
+++ b/src/ui/tray-icon.cpp
@@ -61,11 +61,6 @@ const int kMessageDisplayTimeMSecs = 5000;
 const QString kShellExtFixExecutableName = "shellext-fix.exe";
 const QString kShellFixLogName = "shellext-fix.log";
 #endif
-#ifdef Q_OS_MAC
-void darkmodeWatcher(bool /*new Value*/) {
-    seafApplet->trayIcon()->reloadTrayIcon();
-}
-#endif
 
 QString folderToShow(const CommitDetails& details, const QString& worktree)
 {
@@ -158,9 +153,6 @@ void SeafileTrayIcon::start()
 {
     show();
     refresh_timer_->start(kRefreshInterval);
-#if defined(Q_OS_MAC)
-    utils::mac::set_darkmode_watcher(&darkmodeWatcher);
-#endif
     sync_errors_dialog_ = new SyncErrorsDialog;
     sync_errors_dialog_->updateErrors();
 }

--- a/src/ui/tray-icon.h
+++ b/src/ui/tray-icon.h
@@ -74,6 +74,7 @@ private slots:
     void openSeafileFolder();
     void openLogDirectory();
     void shellExtFix();
+    void toggleTrayIconColor();
     void uploadLogDirectory();
     void about();
     void checkTrayIconMessageQueue();
@@ -109,6 +110,7 @@ private:
     QAction *open_seafile_folder_action_;
     QAction *open_log_directory_action_;
     QAction *shellext_fix_action_;
+    QAction *toggle_tray_icon_color_;
     QAction *upload_log_directory_action_;
     QAction *show_sync_errors_action_;
 

--- a/src/utils/utils-mac.h
+++ b/src/utils/utils-mac.h
@@ -6,8 +6,6 @@
 #include <vector>
 #include <QByteArray>
 
-typedef void DarkModeChangedCallback(bool value);
-
 namespace utils {
 namespace mac {
 // a list for os x versions https://support.apple.com/en-us/HT201260
@@ -28,9 +26,6 @@ void orderFrontRegardless(unsigned long long win_id, bool force = false);
 bool get_auto_start();
 void set_auto_start(bool enabled);
 void copyTextToPasteboard(const QString &text);
-
-bool is_darkmode();
-void set_darkmode_watcher(DarkModeChangedCallback *cb);
 
 QString fix_file_id_url(const QString &path);
 

--- a/src/utils/utils-mac.mm
+++ b/src/utils/utils-mac.mm
@@ -104,48 +104,7 @@ bool isOSXLionOrGreater()
 }
 
 } // namespace mac
-} // namesapce utils
-
-// ****************************************************************************
-// darkmode related
-// ****************************************************************************
-@interface DarkmodeHelper : NSObject
-- (void)getDarkMode;
-@end
-
-static bool darkMode = false;
-static DarkModeChangedCallback *darkModeWatcher = NULL;
-@implementation DarkmodeHelper
-- (id) init {
-    self = [super init];
-
-    // darkmode is available version >= 10.10
-    if (utils::mac::isOSXYosemiteOrGreater()) {
-        [self getDarkMode];
-
-        [[NSDistributedNotificationCenter defaultCenter] addObserver:self
-        selector:@selector(darkModeChanged:)
-        name:@"AppleInterfaceThemeChangedNotification" object:nil];
-    }
-    return self;
-}
-
-- (void)darkModeChanged:(NSNotification *)aNotification
-{
-    bool oldDarkMode = darkMode;
-    [self getDarkMode];
-
-    if (oldDarkMode != darkMode && darkModeWatcher) {
-        darkModeWatcher(darkMode);
-    }
-}
-
-- (void)getDarkMode {
-    NSDictionary *dict = [[NSUserDefaults standardUserDefaults] persistentDomainForName:NSGlobalDomain];
-    id style = [dict objectForKey:@"AppleInterfaceStyle"];
-    darkMode = ( style && [style isKindOfClass:[NSString class]] && NSOrderedSame == [style caseInsensitiveCompare:@"dark"]);
-}
-@end
+} // namespace utils
 
 // ****************************************************************************
 // others
@@ -318,17 +277,6 @@ void set_auto_start(bool enabled)
         CFRelease(currentLoginItems);
         CFRelease(loginItems);
     }
-}
-
-bool is_darkmode() {
-    static DarkmodeHelper *helper = nil;
-    if (!helper) {
-        helper = [[DarkmodeHelper alloc] init];
-    }
-    return darkMode;
-}
-void set_darkmode_watcher(DarkModeChangedCallback *cb) {
-    darkModeWatcher = cb;
 }
 
 void copyTextToPasteboard(const QString &text) {


### PR DESCRIPTION
![Screen Shot 2021-12-01 at 20 16 09](https://user-images.githubusercontent.com/8362329/144345147-2575bfc9-a204-48b1-94b6-98bf1c36def9.png)

The Seafile client's tray icon does not look good on Mac, so I've been researching how to fix the problem and here's what I've found:

- Looking at the source code, the client checks if the OS is in light or dark theme mode. This is wrong because the icon is either white or black depending on the user's background. Changing the theme doesn't change the icons color, so I removed the code checking for dark mode because it's obsolete. 

- According to the Apple guidelines (https://developer.apple.com/design/human-interface-guidelines/macos/extensions/menu-bar-extras), you need to use a template image of one color and set it as a mask, then the OS will automatically change its color when the background changes. Qt supports this with `QIcon::setIsMask(bool isMask)` which is great, but the Seafile client uses some color in the icon. If I enable it, it looks like this:
  ![Screen Shot 2021-12-01 at 20 24 11](https://user-images.githubusercontent.com/8362329/144345998-39d73cd5-2010-4a0e-a6f0-a716d14a0463.png)
  I thought, maybe I could redesign the icons so that it differentiates the colored bits using a transparent border from the main icon, but it would make the icon look a lot worse. It's a potential solution but I didn't want to do it.

- There's an app named Krisp which seems to do what we need, which looks like this:
  ![Screen Shot 2021-12-01 at 20 27 01](https://user-images.githubusercontent.com/8362329/144346297-10b03ac6-fa49-46b4-8e8a-4210809956a9.png)
  I don't know how they did it (because they're not open source 😞) but after researching, I found that Xcode can make *imagesets* which contains multiple images that are light, dark, 2x, 3x, etc and it will use them intelligently. I made an imageset for one of the tray icons but there was no way I could get Qt to understand it, or pass it on directly to the OS. It might be possible to load the imageset through Objective C, but this probably means reimplementing the tray menu outside of Qt. Alternatively, it might be possible to just fetch the current tray menu from Objective C and update the icon from there, instead of through Qt. Either way, this seemed far to complicated for me and I didn't look into it further. It's unfortunate that Qt doesn't allow setting a light or dark variant in QIcon and then passing it on correctly to the tray.

Just this morning, I was playing with a program named Heroic Games Launcher which had a dark icon. But in the tray menu, there was a setting to toggle it between light or dark, and then I realized this is the easiest solution to this problem right now. So I went ahead and implemented it in the Seafile client and added this:

![Screen Shot 2021-12-01 at 20 37 59](https://user-images.githubusercontent.com/8362329/144347392-d6476054-4467-4047-8c32-a288b21a0376.png)

It works great! I added a setting to the settings manager named `trayIconDark` which is set to false by default. This is of course not the most elegant solution, but it's so much better than having a black icon.

I hope my code will do, but let me know if you'd like me to change something. Thank you so much for reading and considering my pr!


 

