### PR TITLE
Fix app not moving in wayland by using the startSystemMove() method

### DIFF
--- a/src/ui/cloud-view.cpp
+++ b/src/ui/cloud-view.cpp
@@ -289,22 +289,9 @@ void CloudView::onCloseBtnClicked()
 bool CloudView::eventFilter(QObject* obj, QEvent* event)
 {
     if (obj == mHeader) {
-        static QPoint oldPos;
         if (event->type() == QEvent::MouseButtonPress) {
-            QMouseEvent* ev = (QMouseEvent*)event;
-            oldPos = ev->globalPos();
-
-            return true;
-        }
-        else if (event->type() == QEvent::MouseMove) {
-            QMouseEvent* ev = (QMouseEvent*)event;
-            const QPoint delta = ev->globalPos() - oldPos;
-
-            MainWindow* win = seafApplet->mainWindow();
-            win->move(win->x() + delta.x(), win->y() + delta.y());
-
-            oldPos = ev->globalPos();
-            return true;
+            QWindow* win = seafApplet->mainWindow()->windowHandle();
+            win->startSystemMove();
         }
     }
     else if (obj == mDropArea) {


### PR DESCRIPTION
Fixes #991, where the app could not be moved under wayland because the protocol does not allow windows to move themselves. This method was introduced in qt 5.15 and [is currently recommended when using client-side decorations](https://www.qt.io/blog/custom-window-decorations) as it allows for native look and feel. 

I have only tested this under under wayland and xwayland but it should be a drop-in replacement in Windows, Linux and Macos. Testing would be appreciated nonetheless.