### PR TITLE
rsa: Fix the build with libressl 3.7

### DIFF
--- a/src/utils/rsa.cpp
+++ b/src/utils/rsa.cpp
@@ -13,7 +13,8 @@ namespace {
 
 /* Forward compatibility functions if libssl < 1.1.0. */
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+   (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 {


### PR DESCRIPTION
Newer versions of libressl no longer need this legacy code path.

Patch from OpenBSD:

https://github.com/openbsd/ports/blob/26afb45924c9faa3bbd31e76a21130bbad474994/net/seafile/client/patches/patch-src_utils_rsa_cpp

Closes: https://github.com/haiwen/seafile-client/pull/1314

```
/tmp/seafile-client/src/utils/rsa.cpp: In function 'int {anonymous}::RSA_set0_key(RSA*, BIGNUM*, BIGNUM*, BIGNUM*)':
/tmp/seafile-client/src/utils/rsa.cpp:24:10: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   24 |    if ((r->n == NULL && n == NULL)
      |          ^~
In file included from /usr/include/openssl/crypto.h:129,
                 from /usr/include/openssl/bio.h:69,
                 from /usr/include/openssl/pem.h:65,
                 from /tmp/seafile-client/src/utils/rsa.cpp:1:
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:25:13: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   25 |        || (r->e == NULL && e == NULL))
      |             ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:28:17: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   28 |        BN_free(r->n);
      |                 ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:29:9: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   29 |        r->n = n;
      |         ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:32:17: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   32 |        BN_free(r->e);
      |                 ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:33:9: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   33 |        r->e = e;
      |         ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:36:17: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   36 |        BN_free(r->d);
      |                 ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:37:9: error: invalid use of incomplete type 'RSA' {aka 'struct rsa_st'}
   37 |        r->d = d;
      |         ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp: In function 'void {anonymous}::RSA_get0_key(const RSA*, const BIGNUM**, const BIGNUM**, const BIGNUM**)':
/tmp/seafile-client/src/utils/rsa.cpp:46:14: error: invalid use of incomplete type 'const RSA' {aka 'const struct rsa_st'}
   46 |        *n = r->n;
      |              ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:48:14: error: invalid use of incomplete type 'const RSA' {aka 'const struct rsa_st'}
   48 |        *e = r->e;
      |              ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:50:14: error: invalid use of incomplete type 'const RSA' {aka 'const struct rsa_st'}
   50 |        *d = r->d;
      |              ^~
/usr/include/openssl/ossl_typ.h:138:16: note: forward declaration of 'RSA' {aka 'struct rsa_st'}
  138 | typedef struct rsa_st RSA;
      |                ^~~~~~
/tmp/seafile-client/src/utils/rsa.cpp: In function 'GString* {anonymous}::public_key_to_gstring(const RSA*)':
/tmp/seafile-client/src/utils/rsa.cpp:88:18: error: call of overloaded 'RSA_get0_key(const RSA*&, const BIGNUM**, const BIGNUM**, std::nullptr_t)' is ambiguous
   88 |     RSA_get0_key (rsa, &n, &e, NULL);
      |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:42:6: note: candidate: 'void {anonymous}::RSA_get0_key(const RSA*, const BIGNUM**, const BIGNUM**, const BIGNUM**)'
   42 | void RSA_get0_key(const RSA *r,
      |      ^~~~~~~~~~~~
In file included from /usr/include/openssl/x509.h:96,
                 from /usr/include/openssl/pem.h:71:
/usr/include/openssl/rsa.h:377:6: note: candidate: 'void RSA_get0_key(const RSA*, const BIGNUM**, const BIGNUM**, const BIGNUM**)'
  377 | void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e,
      |      ^~~~~~~~~~~~
/tmp/seafile-client/src/utils/rsa.cpp: In function 'RSA* private_key_to_pub(RSA*)':
/tmp/seafile-client/src/utils/rsa.cpp:155:18: error: call of overloaded 'RSA_get0_key(RSA*&, const BIGNUM**, const BIGNUM**, std::nullptr_t)' is ambiguous
  155 |     RSA_get0_key (priv, &n, &e, NULL);
      |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
/usr/include/openssl/rsa.h:377:6: note: candidate: 'void RSA_get0_key(const RSA*, const BIGNUM**, const BIGNUM**, const BIGNUM**)'
  377 | void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e,
      |      ^~~~~~~~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:42:6: note: candidate: 'void {anonymous}::RSA_get0_key(const RSA*, const BIGNUM**, const BIGNUM**, const BIGNUM**)'
   42 | void RSA_get0_key(const RSA *r,
      |      ^~~~~~~~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:156:18: error: call of overloaded 'RSA_set0_key(RSA*&, BIGNUM*, BIGNUM*, std::nullptr_t)' is ambiguous
  156 |     RSA_set0_key (pub, BN_dup(n), BN_dup(e), NULL);
      |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/openssl/rsa.h:379:5: note: candidate: 'int RSA_set0_key(RSA*, BIGNUM*, BIGNUM*, BIGNUM*)'
  379 | int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
      |     ^~~~~~~~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:18:5: note: candidate: 'int {anonymous}::RSA_set0_key(RSA*, BIGNUM*, BIGNUM*, BIGNUM*)'
   18 | int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
      |     ^~~~~~~~~~~~
/tmp/seafile-client/src/utils/rsa.cpp: At global scope:
/tmp/seafile-client/src/utils/rsa.cpp:42:6: warning: 'void {anonymous}::RSA_get0_key(const RSA*, const BIGNUM**, const BIGNUM**, const BIGNUM**)' defined but not used [-Wunused-functio ]
   42 | void RSA_get0_key(const RSA *r,
      |      ^~~~~~~~~~~~
/tmp/seafile-client/src/utils/rsa.cpp:18:5: warning: 'int {anonymous}::RSA_set0_key(RSA*, BIGNUM*, BIGNUM*, BIGNUM*)' defined but not used [-Wunused-function]
   18 | int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
      |     ^~~~~~~~~~~~
samu: subcommand failed
```