### PR TITLE
Fix build with Qt v6.9.0

### DIFF
--- a/src/message-poller.cpp
+++ b/src/message-poller.cpp
@@ -1,6 +1,8 @@
 #include <QTimer>
 #include <QDateTime>
 #include <QJsonDocument>
+#include <QJsonValue>
+#include <QRegularExpression>
 
 #include "utils/utils.h"
 #include "utils/translate-commit-desc.h"


### PR DESCRIPTION
Fix `invalid use of incomplete type ...` with Qt 6.9.0.

```
64.40 /tmp/seafile-client/src/seafile-client-9.0.13/src/message-poller.cpp:247:30: error: variable ‘QRegularExpression re’ has initializer but incomplete type
64.40   247 |         QRegularExpression re("Deleted \"(.+)\" and (.+) more files.");
64.40       |                              ^
64.40 /tmp/seafile-client/src/seafile-client-9.0.13/src/message-poller.cpp:248:49: error: invalid use of incomplete type ‘const class QJsonValue’
64.40   248 |         auto match = re.match(doc["delete_files"].toString().trimmed());
64.40       |                                                 ^
64.40 In file included from /usr/include/qt6/QtCore/qobject.h:18,
64.40                  from /usr/include/qt6/QtCore/qabstracteventdispatcher.h:7,
64.40                  from /usr/include/qt6/QtCore/qbasictimer.h:8,
64.40                  from /usr/include/qt6/QtCore/qtimer.h:11,
64.40                  from /usr/include/qt6/QtCore/QTimer:1,
64.40                  from /tmp/seafile-client/src/seafile-client-9.0.13/src/message-poller.cpp:1:
64.40 /usr/include/qt6/QtCore/qmetatype.h:1544:1: note: forward declaration of ‘class QJsonValue’
64.40  1544 | QT_FOR_EACH_STATIC_CORE_CLASS(QT_FORWARD_DECLARE_STATIC_TYPES_ITER)
64.40       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
64.40 /tmp/seafile-client/src/seafile-client-9.0.13/src/message-poller.cpp:255:47: error: invalid use of incomplete type ‘const class QJsonValue’
64.40   255 |                           .arg(doc["repo_name"].toString().trimmed());
64.40       |                                               ^
64.40 /usr/include/qt6/QtCore/qmetatype.h:1544:1: note: forward declaration of ‘class QJsonValue’
64.40  1544 | QT_FOR_EACH_STATIC_CORE_CLASS(QT_FORWARD_DECLARE_STATIC_TYPES_ITER)
64.40       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
64.40 /tmp/seafile-client/src/seafile-client-9.0.13/src/message-poller.cpp:258:66: error: invalid use of incomplete type ‘const class QJsonValue’
64.40   258 |             rpc_client_->addDelConfirmation(doc["confirmation_id"].toString(), false);
64.40       |                                                                  ^
64.40 /usr/include/qt6/QtCore/qmetatype.h:1544:1: note: forward declaration of ‘class QJsonValue’
64.40  1544 | QT_FOR_EACH_STATIC_CORE_CLASS(QT_FORWARD_DECLARE_STATIC_TYPES_ITER)
64.40       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
64.40 /tmp/seafile-client/src/seafile-client-9.0.13/src/message-poller.cpp:260:66: error: invalid use of incomplete type ‘const class QJsonValue’
64.40   260 |             rpc_client_->addDelConfirmation(doc["confirmation_id"].toString(), true);
```