### PR TITLE
Fix progress bar width calculation and modifier column text resize

### DIFF
--- a/src/filebrowser/file-table.cpp
+++ b/src/filebrowser/file-table.cpp
@@ -206,7 +206,7 @@ void FileTableViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
 
             // Customize style using style-sheet..
             QProgressBar progressBar;
-            progressBar.resize(QSize(size.width() - 155, size.height() / 2 - 4));
+            progressBar.resize(QSize(qMax(30, option.rect.width() - 8), option.rect.height() / 2 - 4));
             progressBar.setMinimum(0);
             progressBar.setMaximum(100);
             progressBar.setValue(progress);
@@ -234,7 +234,7 @@ void FileTableViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
             text = model->data(index, Qt::DisplayRole).toString();
         }
         QFont font = model->data(index, Qt::FontRole).value<QFont>();
-        QRect rect(option_rect.topLeft() + QPoint(9, -2), size - QSize(10, 0));
+        QRect rect = option.rect.adjusted(9, -2, -1, 0);
         painter->save();
         painter->setPen(kFontColor);
         painter->setFont(font);


### PR DESCRIPTION
### Fixes and improvements

- **Progress bar** in the "Size" column now uses the actual cell width instead of a hardcoded value, ensuring correct rendering when resizing the window or columns.
- **Modifier column** text now stretches to fill the available width using the correct cell rect, fixing the issue where text did not expand when resizing the column.

#### Before:
![изображение](https://github.com/user-attachments/assets/c8c29388-1363-4641-8570-bf85c3f27c16)

#### After:
![изображение](https://github.com/user-attachments/assets/0dff5bae-c506-40ca-afe4-8bd2cc98aed9)
