### PR TITLE
Auto-resolve transient network sync errors

### DIFF
--- a/src/rpc/sync-error.cpp
+++ b/src/rpc/sync-error.cpp
@@ -5,6 +5,11 @@
 #include "utils/utils.h"
 #include "sync-error.h"
 #include "utils/seafile-error.h"
+#if defined(_MSC_VER)
+#include "include/seafile-error.h"
+#else
+#include <seafile/seafile-error.h>
+#endif
 
 SyncError SyncError::fromGObject(GObject *obj)
 {
@@ -47,4 +52,21 @@ SyncError SyncError::fromGObject(GObject *obj)
 void SyncError::translateErrorStr()
 {
     error_str = translateSyncErrorCode(error_id);
+}
+
+bool SyncError::isNetworkError() const
+{
+    switch (error_id) {
+    case SYNC_ERROR_ID_NETWORK:
+    case SYNC_ERROR_ID_RESOLVE_PROXY:
+    case SYNC_ERROR_ID_RESOLVE_HOST:
+    case SYNC_ERROR_ID_CONNECT:
+    case SYNC_ERROR_ID_SSL:
+    case SYNC_ERROR_ID_TX:
+    case SYNC_ERROR_ID_TX_TIMEOUT:
+    case SYNC_ERROR_ID_UNHANDLED_REDIRECT:
+        return true;
+    default:
+        return false;
+    }
 }

--- a/src/rpc/sync-error.h
+++ b/src/rpc/sync-error.h
@@ -22,6 +22,10 @@ public:
 
     void translateErrorStr();
 
+    // Network errors are transient: they happen when the server is
+    // unreachable and become irrelevant once the connection recovers.
+    bool isNetworkError() const;
+
     bool operator==(const SyncError& rhs) const {
             return id == rhs.id
             && repo_id == rhs.repo_id

--- a/src/server-status-service.cpp
+++ b/src/server-status-service.cpp
@@ -9,7 +9,7 @@
 namespace {
 
 // const int kRefreshInterval = 3 * 60 * 1000; // 3 min
-// const int kRefreshIntervalForUnconnected = 30 * 1000; // 30 sec
+const int kRefreshIntervalForUnconnected = 30 * 1000; // 30 sec
 
 }
 
@@ -30,7 +30,12 @@ ServerStatusService::ServerStatusService(QObject *parent)
 void ServerStatusService::start()
 {
     // refresh_timer_->start(kRefreshInterval);
-    // refresh_unconnected_timer_->start(kRefreshIntervalForUnconnected);
+
+    // Keep retrying servers that are marked disconnected, so the
+    // "servers not connected" tray state resolves itself once the
+    // server is reachable again. This sends no requests while all
+    // servers are connected.
+    refresh_unconnected_timer_->start(kRefreshIntervalForUnconnected);
 }
 
 void ServerStatusService::stop()

--- a/src/ui/sync-errors-dialog.cpp
+++ b/src/ui/sync-errors-dialog.cpp
@@ -18,6 +18,7 @@
 #include "sync-errors-dialog.h"
 #include "ui/tray-icon.h"
 #include "sync-error-service.h"
+#include "server-status-service.h"
 
 class SeafileTrayIcon;
 
@@ -283,9 +284,30 @@ void SyncErrorsTableModel::updateErrors()
     }
     if (errors.size() > 0) {
         if (current_id_ != errors[0].id) {
+            // The errors before the last seen one are the new ones.
+            bool has_new_persistent_error = false;
+            bool has_new_network_error = false;
+            for (size_t i = 0; i < errors.size() && errors[i].id != current_id_; i++) {
+                if (errors[i].isNetworkError()) {
+                    has_new_network_error = true;
+                } else {
+                    has_new_persistent_error = true;
+                }
+            }
             current_id_ = errors[0].id;
             LastSyncError::instance()->saveLatestErrorID(current_id_);
-            emit sigSyncErrorUpdated();
+            if (has_new_persistent_error) {
+                emit sigSyncErrorUpdated();
+            }
+            if (has_new_network_error) {
+                // Network errors are transient, so don't latch the tray
+                // error state (the user could only reset it by opening
+                // this dialog). Instead re-check server connectivity:
+                // the tray shows "servers not connected" while the
+                // server is unreachable, and that state clears itself
+                // once the server can be pinged again.
+                ServerStatusService::instance()->refresh();
+            }
         }
     }
 


### PR DESCRIPTION
When the connection dropped or the server went offline, the tray icon switched to the error state and stayed there even after connectivity was restored. The only way to clear it was to open the sync errors dialog, which is not obvious to users.

Two changes make transient errors resolve themselves:

- New network-type sync errors (connect/resolve/ssl/timeout etc.) no longer latch the tray error flag that only the sync errors dialog resets. Instead they trigger a ServerStatusService refresh, so the tray shows "servers not connected" while the server is actually unreachable. Persistent errors (permissions, conflicts, invalid paths, ...) keep the existing behavior.

- ServerStatusService now re-pings unconnected servers every 30 seconds (the previously disabled refresh timer), so the "servers not connected" state clears itself shortly after the server is reachable again. No requests are sent while all servers are connected.